### PR TITLE
fix: exclude settings.local.json from cli install

### DIFF
--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,2 @@
+**/settings.local.json
+**/__pycache__/

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('uipro')
   .description('CLI to install UI/UX Pro Max skill for AI coding assistants')
-  .version('1.1.0');
+  .version('1.1.1');
 
 program
   .command('init')

--- a/cli/src/utils/extract.ts
+++ b/cli/src/utils/extract.ts
@@ -1,11 +1,13 @@
 import { mkdir, rm, access, cp } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { AIType } from '../types/index.js';
 import { AI_FOLDERS } from '../types/index.js';
 
 const execAsync = promisify(exec);
+
+const EXCLUDED_FILES = ['settings.local.json'];
 
 export async function extractZip(zipPath: string, destDir: string): Promise<void> {
   try {
@@ -56,9 +58,15 @@ export async function copyFolders(
     // Create target directory if needed
     await mkdir(targetPath, { recursive: true });
 
+    // Filter function to exclude certain files
+    const filterFn = (src: string): boolean => {
+      const fileName = basename(src);
+      return !EXCLUDED_FILES.includes(fileName);
+    };
+
     // Copy recursively
     try {
-      await cp(sourcePath, targetPath, { recursive: true });
+      await cp(sourcePath, targetPath, { recursive: true, filter: filterFn });
       copiedFolders.push(folder);
     } catch {
       // Try shell fallback for older Node versions


### PR DESCRIPTION
## Summary
- Add `.npmignore` to exclude `settings.local.json` and `__pycache__` from npm package
- Add filter in `copyFolders()` to skip `settings.local.json` during install
- Prevents overwriting user's permission settings

## Test plan
- [x] Install CLI and verify settings.local.json is not copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)