### PR TITLE
Bug Fix: Windows Unicode Encoding Issue

### DIFF
--- a/.claude/skills/ui-ux-pro-max/scripts/search.py
+++ b/.claude/skills/ui-ux-pro-max/scripts/search.py
@@ -9,7 +9,15 @@ Stacks: html-tailwind, react, nextjs
 """
 
 import argparse
+import sys
+import io
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
+
+# Fix Windows encoding issue
+# Windows CMD defaults to GBK encoding which cannot handle Unicode characters
+# This fix ensures proper UTF-8 output on Windows systems
+if sys.platform == "win32":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
 
 def format_output(result):


### PR DESCRIPTION

### Problem Description
On Windows systems, the `search.py` script fails with a `UnicodeEncodeError` when outputting Unicode characters (such as warning symbols ). This is because Windows CMD defaults to GBK encoding, which cannot handle UTF-8 Unicode characters.

```
UnicodeEncodeError: 'gbk' codec can't encode character '\u26a0' in position 647: illegal multibyte sequence
```

### Solution
Added Windows-specific encoding detection and UTF-8 output wrapping to ensure proper Unicode character display on all platforms.

### Changes Made
- Added `sys` and `io` imports for encoding handling
- Added platform detection for Windows systems
- Wrapped stdout with UTF-8 encoding when running on Windows
- Added detailed comments explaining the fix

### Technical Details
```python
# Fix Windows encoding issue
if sys.platform == "win32":
    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
```


### Impact
This fix ensures the skill works properly for Windows users, maintaining consistent output formatting across all platforms.

### Related Issues
- Cross-platform compatibility
- Unicode character support in output

---

**Fix Type:** Bug Fix  
**Platforms Affected:** Windows  
**Breaking Changes:** None