### PR TITLE
fix: resolve build failure caused by missing brace in detect.ts

### DIFF
--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -30,6 +30,7 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   }
   if (existsSync(join(cwd, '.codex'))) {
     detected.push('codex');
+  }
   if (existsSync(join(cwd, '.roo'))) {
     detected.push('roocode');
   }


### PR DESCRIPTION
Fixes a missing closing brace in detectAIType that caused TypeScript,
esbuild, and Bun to fail with an "Unexpected export" error during build.

This ensures the function is properly closed and restores a successful
CLI build on Windows.
