### PR TITLE
feat: add Claude skill marketplace installation support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "ui-ux-pro-max-skill",
+  "id": "ui-ux-pro-max-skill",
+  "owner": {
+    "name": "nextlevelbuilder"
+  },
+  "metadata": {
+    "description": "UI/UX design intelligence skill with 50 styles, 21 palettes, 50 font pairings, 20 charts, and 9 stack guidelines",
+    "version": "2.0.0"
+  },
+  "plugins": [
+    {
+      "name": "ui-ux-pro-max",
+      "source": "./.claude/skills/ui-ux-pro-max",
+      "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, and shadcn/ui.",
+      "version": "2.0.0",
+      "author": {
+        "name": "nextlevelbuilder"
+      },
+      "keywords": [
+        "ui",
+        "ux",
+        "design",
+        "styles",
+        "typography",
+        "color-palette",
+        "accessibility",
+        "charts",
+        "components"
+      ],
+      "category": "design",
+      "strict": false
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ Each rule includes:
 
 ## Installation
 
+### Using Claude Marketplace (Claude Code)
+
+Install directly in Claude Code with two commands:
+
+```
+/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill
+/plugin install ui-ux-pro-max@ui-ux-pro-max-skill
+```
+
 ### Using CLI (Recommended)
 
 ```bash


### PR DESCRIPTION
## Summary

This PR adds support for Claude's native skill marketplace installation feature, enabling users to install the skill with simple commands instead of manual file copying.

## Changes

### Added
- \.claude-plugin/marketplace.json\ - Marketplace manifest file that enables the \/plugin marketplace add\ command

### Modified
- \README.md\ - Added marketplace installation instructions as the first option for Claude Code users

## How to Install (After Merge)

\\\
/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill
/plugin install ui-ux-pro-max@ui-ux-pro-max-skill
\\\

## Testing

The installation can be verified after merge by running the above commands in Claude Code.

## Related

This addresses the need for easier Claude skill installation by leveraging the native marketplace functionality.