### PR TITLE
feat: Add design system persistence with Master + Overrides pattern

### DIFF
--- a/.agent/workflows/ui-ux-pro-max.md
+++ b/.agent/workflows/ui-ux-pro-max.md
@@ -1,7 +1,3 @@
----
-description: Plan and implement UI
----
-
 # ui-ux-pro-max
 
 Comprehensive design guide for web and mobile applications. Contains 50+ styles, 97 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 9 technology stacks. Searchable database with priority-based recommendations.
@@ -64,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -89,8 +110,9 @@ Get implementation-specific best practices. If user doesn't specify a stack, **d
 ```bash
 python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
 ```
-Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
 
+Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -149,6 +149,40 @@ This command:
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for **hierarchical retrieval across sessions**, add `--persist`:
+
+```bash
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
+**Context-aware retrieval prompt:**
+```
+I am building the [Page Name] page. Please read design-system/MASTER.md.
+Also check if design-system/pages/[page-name].md exists.
+If the page file exists, prioritize its rules.
+If not, use the Master rules exclusively.
+Now, generate the code...
+```
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:

--- a/.claude/skills/ui-ux-pro-max/scripts/search.py
+++ b/.claude/skills/ui-ux-pro-max/scripts/search.py
@@ -4,14 +4,19 @@
 UI/UX Pro Max Search - BM25 search engine for UI/UX style guides
 Usage: python search.py "<query>" [--domain <domain>] [--stack <stack>] [--max-results 3]
        python search.py "<query>" --design-system [-p "Project Name"]
+       python search.py "<query>" --design-system --persist [-p "Project Name"] [--page "dashboard"]
 
 Domains: style, prompt, color, chart, landing, product, ux, typography
 Stacks: html-tailwind, react, nextjs
+
+Persistence (Master + Overrides pattern):
+  --persist    Save design system to design-system/MASTER.md
+  --page       Also create a page-specific override file in design-system/pages/
 """
 
 import argparse
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
-from design_system import generate_design_system
+from design_system import generate_design_system, persist_design_system
 
 
 def format_output(result):
@@ -51,13 +56,37 @@ if __name__ == "__main__":
     parser.add_argument("--design-system", "-ds", action="store_true", help="Generate complete design system recommendation")
     parser.add_argument("--project-name", "-p", type=str, default=None, help="Project name for design system output")
     parser.add_argument("--format", "-f", choices=["ascii", "markdown"], default="ascii", help="Output format for design system")
+    # Persistence (Master + Overrides pattern)
+    parser.add_argument("--persist", action="store_true", help="Save design system to design-system/MASTER.md (creates hierarchical structure)")
+    parser.add_argument("--page", type=str, default=None, help="Create page-specific override file in design-system/pages/")
+    parser.add_argument("--output-dir", "-o", type=str, default=None, help="Output directory for persisted files (default: current directory)")
 
     args = parser.parse_args()
 
     # Design system takes priority
     if args.design_system:
-        result = generate_design_system(args.query, args.project_name, args.format)
+        result = generate_design_system(
+            args.query, 
+            args.project_name, 
+            args.format,
+            persist=args.persist,
+            page=args.page,
+            output_dir=args.output_dir
+        )
         print(result)
+        
+        # Print persistence confirmation
+        if args.persist:
+            print("\n" + "=" * 60)
+            print("✅ Design system persisted to design-system/ folder")
+            print("   📄 design-system/MASTER.md (Global Source of Truth)")
+            if args.page:
+                page_filename = args.page.lower().replace(' ', '-')
+                print(f"   📄 design-system/pages/{page_filename}.md (Page Overrides)")
+            print("")
+            print("📖 Usage: When building a page, check design-system/pages/[page].md first.")
+            print("   If exists, its rules override MASTER.md. Otherwise, use MASTER.md.")
+            print("=" * 60)
     # Stack search
     elif args.stack:
         result = search_stack(args.query, args.stack, args.max_results)

--- a/.cursor/commands/ui-ux-pro-max.md
+++ b/.cursor/commands/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:

--- a/.kiro/steering/ui-ux-pro-max.md
+++ b/.kiro/steering/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -87,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/.qoder/skills/ui-ux-pro-max.md
+++ b/.qoder/skills/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -86,8 +111,8 @@ Get implementation-specific best practices. If user doesn't specify a stack, **d
 python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
-Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`
-
+Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+, `jetpack-compose`
 ---
 
 ## Search Reference
@@ -120,6 +145,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 | `react-native` | Components, Navigation, Lists |
 | `flutter` | Widgets, State, Layout, Theming |
 | `shadcn` | shadcn/ui components, theming, forms, patterns |
+| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 
 ---
 

--- a/.roo/rules/ui-ux-pro-max.md
+++ b/.roo/rules/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -86,8 +111,8 @@ Get implementation-specific best practices. If user doesn't specify a stack, **d
 python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
-Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`
-
+Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+, `jetpack-compose`
 ---
 
 ## Search Reference
@@ -120,6 +145,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 | `react-native` | Components, Navigation, Lists |
 | `flutter` | Widgets, State, Layout, Theming |
 | `shadcn` | shadcn/ui components, theming, forms, patterns |
+| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 
 ---
 

--- a/.shared/ui-ux-pro-max/scripts/search.py
+++ b/.shared/ui-ux-pro-max/scripts/search.py
@@ -4,14 +4,19 @@
 UI/UX Pro Max Search - BM25 search engine for UI/UX style guides
 Usage: python search.py "<query>" [--domain <domain>] [--stack <stack>] [--max-results 3]
        python search.py "<query>" --design-system [-p "Project Name"]
+       python search.py "<query>" --design-system --persist [-p "Project Name"] [--page "dashboard"]
 
 Domains: style, prompt, color, chart, landing, product, ux, typography
 Stacks: html-tailwind, react, nextjs
+
+Persistence (Master + Overrides pattern):
+  --persist    Save design system to design-system/MASTER.md
+  --page       Also create a page-specific override file in design-system/pages/
 """
 
 import argparse
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
-from design_system import generate_design_system
+from design_system import generate_design_system, persist_design_system
 
 
 def format_output(result):
@@ -51,13 +56,37 @@ if __name__ == "__main__":
     parser.add_argument("--design-system", "-ds", action="store_true", help="Generate complete design system recommendation")
     parser.add_argument("--project-name", "-p", type=str, default=None, help="Project name for design system output")
     parser.add_argument("--format", "-f", choices=["ascii", "markdown"], default="ascii", help="Output format for design system")
+    # Persistence (Master + Overrides pattern)
+    parser.add_argument("--persist", action="store_true", help="Save design system to design-system/MASTER.md (creates hierarchical structure)")
+    parser.add_argument("--page", type=str, default=None, help="Create page-specific override file in design-system/pages/")
+    parser.add_argument("--output-dir", "-o", type=str, default=None, help="Output directory for persisted files (default: current directory)")
 
     args = parser.parse_args()
 
     # Design system takes priority
     if args.design_system:
-        result = generate_design_system(args.query, args.project_name, args.format)
+        result = generate_design_system(
+            args.query, 
+            args.project_name, 
+            args.format,
+            persist=args.persist,
+            page=args.page,
+            output_dir=args.output_dir
+        )
         print(result)
+        
+        # Print persistence confirmation
+        if args.persist:
+            print("\n" + "=" * 60)
+            print("✅ Design system persisted to design-system/ folder")
+            print("   📄 design-system/MASTER.md (Global Source of Truth)")
+            if args.page:
+                page_filename = args.page.lower().replace(' ', '-')
+                print(f"   📄 design-system/pages/{page_filename}.md (Page Overrides)")
+            print("")
+            print("📖 Usage: When building a page, check design-system/pages/[page].md first.")
+            print("   If exists, its rules override MASTER.md. Otherwise, use MASTER.md.")
+            print("=" * 60)
     # Stack search
     elif args.stack:
         result = search_stack(args.query, args.stack, args.max_results)

--- a/.windsurf/workflows/ui-ux-pro-max.md
+++ b/.windsurf/workflows/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -87,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/README.md
+++ b/README.md
@@ -359,6 +359,41 @@ python3 .claude/skills/ui-ux-pro-max/scripts/search.py "form validation" --stack
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "responsive layout" --stack html-tailwind
 ```
 
+### Persist Design System (Master + Overrides Pattern)
+
+Save your design system to files for **hierarchical retrieval across sessions**:
+
+```bash
+# Generate and persist to design-system/MASTER.md
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
+
+# Also create a page-specific override file
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp" --page "dashboard"
+```
+
+This creates a `design-system/` folder structure:
+
+```
+design-system/
+├── MASTER.md           # Global Source of Truth (colors, typography, spacing, components)
+└── pages/
+    └── dashboard.md    # Page-specific overrides (only deviations from Master)
+```
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
+**Context-aware retrieval prompt:**
+```
+I am building the [Page Name] page. Please read design-system/MASTER.md.
+Also check if design-system/pages/[page-name].md exists.
+If the page file exists, prioritize its rules.
+If not, use the Master rules exclusively.
+Now, generate the code...
+```
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=nextlevelbuilder/ui-ux-pro-max-skill&type=Date)](https://star-history.com/#nextlevelbuilder/ui-ux-pro-max-skill&Date)

--- a/cli/assets/.agent/workflows/ui-ux-pro-max.md
+++ b/cli/assets/.agent/workflows/ui-ux-pro-max.md
@@ -1,7 +1,3 @@
----
-description: Plan and implement UI
----
-
 # ui-ux-pro-max
 
 Comprehensive design guide for web and mobile applications. Contains 50+ styles, 97 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 9 technology stacks. Searchable database with priority-based recommendations.
@@ -64,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -91,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/cli/assets/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/cli/assets/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -149,6 +149,40 @@ This command:
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for **hierarchical retrieval across sessions**, add `--persist`:
+
+```bash
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .claude/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
+**Context-aware retrieval prompt:**
+```
+I am building the [Page Name] page. Please read design-system/MASTER.md.
+Also check if design-system/pages/[page-name].md exists.
+If the page file exists, prioritize its rules.
+If not, use the Master rules exclusively.
+Now, generate the code...
+```
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -208,8 +242,8 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 | `swiftui` | Views, State, Navigation, Animation |
 | `react-native` | Components, Navigation, Lists |
 | `flutter` | Widgets, State, Layout, Theming |
-| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 | `shadcn` | shadcn/ui components, theming, forms, patterns |
+| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 
 ---
 

--- a/cli/assets/.cursor/commands/ui-ux-pro-max.md
+++ b/cli/assets/.cursor/commands/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -87,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/cli/assets/.kiro/steering/ui-ux-pro-max.md
+++ b/cli/assets/.kiro/steering/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -87,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference

--- a/cli/assets/.qoder/skills/ui-ux-pro-max.md
+++ b/cli/assets/.qoder/skills/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -86,8 +111,8 @@ Get implementation-specific best practices. If user doesn't specify a stack, **d
 python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
-Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`
-
+Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+, `jetpack-compose`
 ---
 
 ## Search Reference
@@ -120,6 +145,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 | `react-native` | Components, Navigation, Lists |
 | `flutter` | Widgets, State, Layout, Theming |
 | `shadcn` | shadcn/ui components, theming, forms, patterns |
+| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 
 ---
 

--- a/cli/assets/.roo/rules/ui-ux-pro-max.md
+++ b/cli/assets/.roo/rules/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -86,8 +111,8 @@ Get implementation-specific best practices. If user doesn't specify a stack, **d
 python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
-Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`
-
+Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+, `jetpack-compose`
 ---
 
 ## Search Reference
@@ -120,6 +145,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 | `react-native` | Components, Navigation, Lists |
 | `flutter` | Widgets, State, Layout, Theming |
 | `shadcn` | shadcn/ui components, theming, forms, patterns |
+| `jetpack-compose` | Composables, Modifiers, State Hoisting, Recomposition |
 
 ---
 

--- a/cli/assets/.shared/ui-ux-pro-max/scripts/search.py
+++ b/cli/assets/.shared/ui-ux-pro-max/scripts/search.py
@@ -4,14 +4,19 @@
 UI/UX Pro Max Search - BM25 search engine for UI/UX style guides
 Usage: python search.py "<query>" [--domain <domain>] [--stack <stack>] [--max-results 3]
        python search.py "<query>" --design-system [-p "Project Name"]
+       python search.py "<query>" --design-system --persist [-p "Project Name"] [--page "dashboard"]
 
 Domains: style, prompt, color, chart, landing, product, ux, typography
 Stacks: html-tailwind, react, nextjs
+
+Persistence (Master + Overrides pattern):
+  --persist    Save design system to design-system/MASTER.md
+  --page       Also create a page-specific override file in design-system/pages/
 """
 
 import argparse
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
-from design_system import generate_design_system
+from design_system import generate_design_system, persist_design_system
 
 
 def format_output(result):
@@ -51,13 +56,37 @@ if __name__ == "__main__":
     parser.add_argument("--design-system", "-ds", action="store_true", help="Generate complete design system recommendation")
     parser.add_argument("--project-name", "-p", type=str, default=None, help="Project name for design system output")
     parser.add_argument("--format", "-f", choices=["ascii", "markdown"], default="ascii", help="Output format for design system")
+    # Persistence (Master + Overrides pattern)
+    parser.add_argument("--persist", action="store_true", help="Save design system to design-system/MASTER.md (creates hierarchical structure)")
+    parser.add_argument("--page", type=str, default=None, help="Create page-specific override file in design-system/pages/")
+    parser.add_argument("--output-dir", "-o", type=str, default=None, help="Output directory for persisted files (default: current directory)")
 
     args = parser.parse_args()
 
     # Design system takes priority
     if args.design_system:
-        result = generate_design_system(args.query, args.project_name, args.format)
+        result = generate_design_system(
+            args.query, 
+            args.project_name, 
+            args.format,
+            persist=args.persist,
+            page=args.page,
+            output_dir=args.output_dir
+        )
         print(result)
+        
+        # Print persistence confirmation
+        if args.persist:
+            print("\n" + "=" * 60)
+            print("✅ Design system persisted to design-system/ folder")
+            print("   📄 design-system/MASTER.md (Global Source of Truth)")
+            if args.page:
+                page_filename = args.page.lower().replace(' ', '-')
+                print(f"   📄 design-system/pages/{page_filename}.md (Page Overrides)")
+            print("")
+            print("📖 Usage: When building a page, check design-system/pages/[page].md first.")
+            print("   If exists, its rules override MASTER.md. Otherwise, use MASTER.md.")
+            print("=" * 60)
     # Stack search
     elif args.stack:
         result = search_stack(args.query, args.stack, args.max_results)

--- a/cli/assets/.windsurf/workflows/ui-ux-pro-max.md
+++ b/cli/assets/.windsurf/workflows/ui-ux-pro-max.md
@@ -60,6 +60,31 @@ This command:
 python3 .shared/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
+### Step 2b: Persist Design System (Master + Overrides Pattern)
+
+To save the design system for hierarchical retrieval across sessions, add `--persist`:
+
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+```
+
+This creates:
+- `design-system/MASTER.md` — Global Source of Truth with all design rules
+- `design-system/pages/` — Folder for page-specific overrides
+
+**With page-specific override:**
+```bash
+python3 .shared/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+```
+
+This also creates:
+- `design-system/pages/dashboard.md` — Page-specific deviations from Master
+
+**How hierarchical retrieval works:**
+1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+2. If the page file exists, its rules **override** the Master file
+3. If not, use `design-system/MASTER.md` exclusively
+
 ### Step 3: Supplement with Detailed Searches (as needed)
 
 After getting the design system, use domain searches to get additional details:
@@ -87,7 +112,7 @@ python3 .shared/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwin
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
-
+, `jetpack-compose`
 ---
 
 ## Search Reference


### PR DESCRIPTION

### Problem
Users need to maintain consistent design context across chat sessions. Currently, the generated design system is only displayed in the terminal and not persisted to files, forcing users to regenerate it or manually copy the output.

### Solution
Added `--persist` and `--page` flags to automatically save design systems to a structured folder hierarchy that **paves the pathway for a Master + Extension system**:
- `design-system/MASTER.md` — Global Source of Truth (Brand Identity)
- `design-system/pages/[page-name].md` — Page-specific overrides (Context-aware rules)

This enables a **"Landing Page → App Dashboard" translation workflow** where the Master establishes brand identity from public-facing pages (marketing site, homepage, landing), and page overrides adapt the design for the logged-in application (dashboard, admin panel, data views).

### The Problem This Solves

**Common Scenario:**
1. You generate a design system for a "SaaS Landing Page" → Beautiful, spacious, large hero text (H1: 64px), lots of whitespace
2. You try to build the actual app dashboard → The spacing is too loose, headers are too large, can't fit data tables

**The Gap:**
- **Landing pages** need breathing room, emotional impact, large CTAs
- **App dashboards** need density, data tables, compact layouts, info-rich cards

Same brand (colors, fonts), different **UI density and component priorities**.

### Changes
- ✅ Added `persist_design_system()`, `format_master_md()`, and `format_page_override_md()` functions to `design_system.py`
- ✅ Added `--persist`, `--page`, and `--output-dir` flags to CLI
- ✅ MASTER.md includes hierarchical override logic, color palette, typography, spacing, shadows, component specs, and anti-patterns
- ✅ Page override files are templates for documenting deviations from Master
- ✅ Updated documentation for all AI assistants (Claude, Cursor, Windsurf, Kiro, Qoder, Roo)
- ✅ Updated README.md with usage examples

### Usage

#### Step 1: Generate Master Design System (Landing Page / Public Site)
```bash
# Generate landing page design system and persist it
python3 .shared/ui-ux-pro-max/scripts/search.py "FinTech SaaS landing page" --design-system --persist -p "MyApp"
```

This creates `design-system/MASTER.md` with:
- Brand colors (e.g., Teal #008080)
- Brand typography (e.g., Inter)
- Landing page spacing (large: 64px hero, 48px sections)
- Marketing-focused components (large buttons, hero cards)

#### Step 2: Create App-Specific Overrides (Dashboard / Logged-In Views)
When building the actual SaaS dashboard, use this **"App Adaptation" prompt**:

```
I am now building the App Dashboard (logged-in view after user signs in).

Read: design-system/MASTER.md

Goal: Adapt the landing page design for the application interface.

Apply these 'Dashboard Modifications':

1. Spacing: Reduce from 48px sections to 24px. Reduce card padding from 32px to 16px.
2. Typography: Keep Inter font, but reduce sizes:
   - H1: 64px → 24px (page titles in app)
   - H2: 48px → 20px (section headers)
   - Body: Keep at 16px
3. Colors: Keep Teal #008080 for buttons/links ONLY. Use neutral grays for backgrounds/cards.
4. Components: 
   - Cards: Reduce shadow, add borders, compact padding
   - Tables: Create data grid component with alternating row colors
   - Sidebar: Create compact navigation (not full-width like landing nav)

Output:
- Generate the Dashboard code
- Save these app-specific rules to design-system/pages/app-dashboard.md
```

Or use the CLI directly:
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "SaaS dashboard data tables" --design-system --persist -p "MyApp" --page "app-dashboard"
```

### Practical Workflow Example

**Scenario:** Building a FinTech SaaS with public website + logged-in app

```
Project Structure:
├── public website (landing, pricing, about) → Use MASTER.md
└── app (dashboard, settings, analytics)    → Use pages/app-dashboard.md
```

1. **Generate Master (Landing Page Design)**
   ```bash
   python3 .shared/ui-ux-pro-max/scripts/search.py "FinTech SaaS" --design-system --persist -p "FinanceApp"
   ```
   → `design-system/MASTER.md` = Spacious layout, large typography, emotional branding

2. **Adapt for App Dashboard**
   Prompt the AI:
   ```
   Read design-system/MASTER.md and create app-specific rules:
   - Tighter spacing (24px instead of 48px)
   - Smaller headers (H1: 24px instead of 64px)
   - Data-focused: tables, compact cards, sidebar navigation
   - Save to design-system/pages/app-dashboard.md
   ```

3. **Build Any App Page**
   ```
   Building the Analytics page.
   Check design-system/pages/analytics.md → Not found
   Fallback to design-system/pages/app-dashboard.md → Use these rules
   ```

---

## Example Usage: Manual Design System Retrieval

**Important:** This feature is **explicitly manual**. The AI does NOT automatically detect or read `design-system/MASTER.md`. You must tell it to read the file in each new chat session.

### Example 1: Basic Workflow

**Session 1 - Generate and Persist:**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "FinTech SaaS" --design-system --persist -p "MyApp"
```
✅ Creates `design-system/MASTER.md`

**Session 2 - New Chat, Build Landing Page:**
```
Read design-system/MASTER.md and build the landing page hero section
```

**Session 3 - New Chat, Build Pricing Page:**
```
Read design-system/MASTER.md and create the pricing page
```

---

### Example 2: Landing Page → Dashboard Translation

**Step 1: Generate Landing Page Design**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "SaaS landing page" --design-system --persist -p "ProductName"
```
✅ Creates `design-system/MASTER.md` (spacious, large text, marketing-focused)

**Step 2: Build Landing Page**
```
Read design-system/MASTER.md and build the landing page
```

**Step 3: Adapt for App Dashboard**
```
Read design-system/MASTER.md and create app-specific rules:
- Reduce spacing from 48px to 24px
- Reduce H1 from 64px to 24px
- Keep colors but use primary only for buttons
- Create compact sidebar navigation
- Save to design-system/pages/app-dashboard.md
```

**Step 4: Build Dashboard (New Chat)**
```
Read design-system/MASTER.md.
Then read design-system/pages/app-dashboard.md (prioritize these rules).
Build the analytics dashboard.
```

---

### Example 3: Multi-Page SaaS App

**Initial Setup:**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "B2B SaaS" --design-system --persist -p "EnterpriseApp"
```

**Building Different Pages (Each in New Chat):**

```
# Settings Page
Read design-system/MASTER.md.
Check if design-system/pages/settings.md exists.
If not, use MASTER rules.
Build the settings page.
```

```
# User Profile Page  
Read design-system/MASTER.md.
Check if design-system/pages/profile.md exists.
If not, use MASTER rules.
Build the user profile page.
```

```
# Reports Page
Read design-system/MASTER.md.
Check if design-system/pages/reports.md exists.
If not, use MASTER rules.
Build the reports page with data tables.
```

---

### Example 4: Creating Page-Specific Overrides

**Generate Dashboard-Specific Rules:**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "data dashboard dense" --design-system --persist -p "MyApp" --page "dashboard"
```
✅ Creates:
- `design-system/MASTER.md` (if doesn't exist)
- `design-system/pages/dashboard.md`

**Using the Override:**
```
Read design-system/MASTER.md.
Read design-system/pages/dashboard.md (these rules override Master).
Build the analytics dashboard.
```

---

### Example 5: E-commerce Site

**Generate Master:**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "luxury e-commerce fashion" --design-system --persist -p "LuxuryShop"
```

**Build Homepage:**
```
Read design-system/MASTER.md and build the homepage with hero carousel
```

**Build Product Page (New Chat):**
```
Read design-system/MASTER.md and build the product detail page
```

**Build Checkout (New Chat):**
```
Read design-system/MASTER.md and create the checkout flow
```

---

### Example 6: Healthcare Platform

**Initial Design System:**
```bash
python3 .shared/ui-ux-pro-max/scripts/search.py "healthcare patient portal" --design-system --persist -p "HealthApp"
```

**Patient View:**
```
Read design-system/MASTER.md and build the patient dashboard
```

**Doctor View (New Chat):**
```
Read design-system/MASTER.md.
Create doctor-specific overrides:
- More dense layout for medical records
- Additional status colors for patient conditions
- Save to design-system/pages/doctor-dashboard.md
Then build the doctor dashboard.
```

---

### Key Takeaways

1. **Always explicitly tell the AI to read the file:**
   - ✅ "Read design-system/MASTER.md and build X"
   - ❌ "Build X" (AI won't automatically check for the file)

2. **Check for page overrides manually:**
   ```
   Read design-system/MASTER.md.
   Check if design-system/pages/[page-name].md exists.
   If found, prioritize those rules.
   ```

3. **The files persist, but the AI's memory doesn't:**
   - Every new chat = you need to tell it to read the files again
   - This is the tradeoff for having persistent design context

---

### Benefits
- ✨ **Persistent design context** across sessions
- 📁 **Organized hierarchical structure** (Master + Overrides)
- 🎯 **Landing page vs App separation** enabled
- 🔄 **Context-aware AI** reads page-specific rules first
- 📝 **Clear documentation** for developers
- 🧩 **Extensible pattern** for multi-context design systems

### Why This Matters
The landing page design (spacious, large text, emotional) doesn't work for dashboards (dense, data tables, compact). This pattern lets you keep consistent **branding** (colors, fonts) while adapting **UI density** for different contexts—same company identity, optimized for the use case.
