### PR TITLE
fix(cli): read version dynamically from package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { initCommand } from './commands/init.js';
 import { versionsCommand } from './commands/versions.js';
 import { updateCommand } from './commands/update.js';
 import type { AIType } from './types/index.js';
 import { AI_TYPES } from './types/index.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'));
+
 const program = new Command();
 
 program
   .name('uipro')
   .description('CLI to install UI/UX Pro Max skill for AI coding assistants')
-  .version('1.9.0');
+  .version(pkg.version);
 
 program
   .command('init')


### PR DESCRIPTION
## Summary
- Remove hardcoded version string (was stuck at 1.9.0 while package.json had 2.0.0)
- Read version from package.json at runtime using ESM imports
- Bump version to 2.1.0

## Changes
- `cli/src/index.ts`: Import fs/url/path and read version from package.json
- `cli/package.json`: Bump to 2.1.0

## Test
```bash
cd cli && npx bun build src/index.ts --outdir dist --target node
node dist/index.js --version
# Output: 2.1.0
```

🤖 Generated with [Claude Code](https://claude.ai/code)