### PR TITLE
feat(cli): add --global flag for user-level skill installation

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,9 +11,9 @@
     "assets"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node",
-    "dev": "bun run src/index.ts",
-    "prepublishOnly": "bun run build"
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --packages=external",
+    "dev": "node --loader ts-node/esm src/index.ts",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "ui",
@@ -34,8 +34,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "commander": "^12.1.0",
     "chalk": "^5.3.0",
+    "commander": "^12.1.0",
     "ora": "^8.1.1",
     "prompts": "^2.4.2"
   },
@@ -43,6 +43,7 @@
     "@types/bun": "^1.1.14",
     "@types/node": "^22.10.1",
     "@types/prompts": "^2.4.9",
+    "esbuild": "^0.27.2",
     "typescript": "^5.7.2"
   }
 }

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -1,0 +1,510 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chalk:
+        specifier: ^5.3.0
+        version: 5.6.2
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      ora:
+        specifier: ^8.1.1
+        version: 8.2.0
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.1.14
+        version: 1.3.6
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.7
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
+      esbuild:
+        specifier: ^0.27.2
+        version: 0.27.2
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/bun@1.3.6':
+    resolution: {integrity: sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==}
+
+  '@types/node@22.19.7':
+    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
+  '@types/prompts@2.4.9':
+    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  bun-types@1.3.6:
+    resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@types/bun@1.3.6':
+    dependencies:
+      bun-types: 1.3.6
+
+  '@types/node@22.19.7':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/prompts@2.4.9':
+    dependencies:
+      '@types/node': 22.19.7
+      kleur: 3.0.3
+
+  ansi-regex@6.2.2: {}
+
+  bun-types@1.3.6:
+    dependencies:
+      '@types/node': 22.19.7
+
+  chalk@5.6.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
+  commander@12.1.0: {}
+
+  emoji-regex@10.6.0: {}
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
+
+  get-east-asian-width@1.4.0: {}
+
+  is-interactive@2.0.0: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  kleur@3.0.3: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
+  mimic-function@5.0.1: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
+
+  stdin-discarder@0.2.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,11 +1,13 @@
 import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { mkdir, readFile, writeFile, rename } from 'node:fs/promises';
 import chalk from 'chalk';
 import ora from 'ora';
 import prompts from 'prompts';
-import type { AIType } from '../types/index.js';
-import { AI_TYPES } from '../types/index.js';
-import { copyFolders, installFromZip, createTempDir, cleanup } from '../utils/extract.js';
+import type { AIType, GlobalPathConfig } from '../types/index.js';
+import { AI_TYPES, GLOBAL_PATHS, GLOBAL_UNSUPPORTED_MESSAGES } from '../types/index.js';
+import { copyFolders, installFromZip, createTempDir, cleanup, copyFoldersGlobal } from '../utils/extract.js';
 import { detectAIType, getAITypeDescription } from '../utils/detect.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -24,6 +26,115 @@ interface InitOptions {
   ai?: AIType;
   force?: boolean;
   offline?: boolean;
+  global?: boolean;
+  path?: string;
+}
+
+/**
+ * Resolve ~ to home directory in path
+ */
+function expandHomePath(path: string): string {
+  if (path.startsWith('~')) {
+    return join(homedir(), path.slice(1));
+  }
+  return path;
+}
+
+/**
+ * Get the default global path for a provider
+ */
+function getDefaultGlobalPath(aiType: AIType): string | null {
+  if (aiType === 'all') return null;
+  const config = GLOBAL_PATHS[aiType];
+  if (!config) return null;
+  return expandHomePath(config.path);
+}
+
+/**
+ * Check if provider supports global installation
+ */
+function supportsGlobal(aiType: AIType): boolean {
+  if (aiType === 'all') return false;
+  return GLOBAL_PATHS[aiType] !== null;
+}
+
+/**
+ * Get global config for a provider
+ */
+function getGlobalConfig(aiType: AIType): GlobalPathConfig | null {
+  if (aiType === 'all') return null;
+  return GLOBAL_PATHS[aiType];
+}
+
+/**
+ * YAML frontmatter to add to SKILL.md for providers that need it
+ */
+const YAML_FRONTMATTER = `---
+name: UI/UX Pro Max
+description: Comprehensive design guide for web and mobile applications. Contains 50+ styles, 97 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types. Use when the user requests UI/UX work (design, build, create, implement, review, fix, improve).
+---
+
+`;
+
+/**
+ * Add YAML frontmatter to a skill file if needed
+ */
+async function ensureYamlFrontmatter(filePath: string): Promise<void> {
+  try {
+    let content = await readFile(filePath, 'utf-8');
+    if (!content.startsWith('---')) {
+      content = YAML_FRONTMATTER + content;
+      await writeFile(filePath, content, 'utf-8');
+    }
+  } catch {
+    // File doesn't exist or can't be read - skip
+  }
+}
+
+/**
+ * Transform paths in skill files from local to global
+ * e.g., .shared/ui-ux-pro-max/ -> ~/.gemini/antigravity/skills/ui-ux-pro-max/
+ */
+async function transformPathsToGlobal(filePath: string, globalBasePath: string): Promise<void> {
+  try {
+    let content = await readFile(filePath, 'utf-8');
+
+    // Replace .shared/ui-ux-pro-max/ with global path
+    const globalPath = globalBasePath.replace(homedir(), '~');
+    content = content.replace(/\.shared\/ui-ux-pro-max\//g, `${globalPath}/`);
+
+    // Also update relative script paths in Python commands
+    // e.g., python3 .shared/ui-ux-pro-max/scripts/ -> python3 ~/.../scripts/
+    content = content.replace(/python3?\s+\.shared\/ui-ux-pro-max\//g, `python3 ${globalPath}/`);
+
+    await writeFile(filePath, content, 'utf-8');
+  } catch {
+    // File doesn't exist or can't be read - skip
+  }
+}
+
+/**
+ * Rename workflow file to expected skill entry file
+ */
+async function renameToSkillEntry(targetDir: string, config: GlobalPathConfig): Promise<void> {
+  const possibleSources = [
+    'ui-ux-pro-max.md',
+    'workflows/ui-ux-pro-max.md',
+    'commands/ui-ux-pro-max.md',
+    'skills/ui-ux-pro-max/ui-ux-pro-max.md',
+  ];
+
+  for (const source of possibleSources) {
+    const sourcePath = join(targetDir, source);
+    const destPath = join(targetDir, config.skillEntryFile);
+
+    try {
+      await rename(sourcePath, destPath);
+      return;
+    } catch {
+      // Try next source
+    }
+  }
 }
 
 /**
@@ -33,7 +144,8 @@ interface InitOptions {
 async function tryGitHubInstall(
   targetDir: string,
   aiType: AIType,
-  spinner: ReturnType<typeof ora>
+  spinner: ReturnType<typeof ora>,
+  isGlobal: boolean = false
 ): Promise<string[] | null> {
   let tempDir: string | null = null;
 
@@ -56,7 +168,8 @@ async function tryGitHubInstall(
     const { copiedFolders, tempDir: extractedTempDir } = await installFromZip(
       zipPath,
       targetDir,
-      aiType
+      aiType,
+      isGlobal
     );
 
     // Cleanup temp directory
@@ -123,17 +236,67 @@ export async function initCommand(options: InitOptions): Promise<void> {
     aiType = response.aiType as AIType;
   }
 
+  // Handle global installation
+  let targetDir = process.cwd();
+  let isGlobal = false;
+  let globalConfig: GlobalPathConfig | null = null;
+
+  if (options.global) {
+    // Check if provider supports global installation
+    if (aiType === 'all') {
+      logger.error('Global installation is not supported with --ai all');
+      logger.info('Please specify a single AI provider for global installation');
+      process.exit(1);
+    }
+
+    if (!supportsGlobal(aiType)) {
+      const message = GLOBAL_UNSUPPORTED_MESSAGES[aiType] ||
+        `${aiType} does not support global installation. Use local install instead.`;
+      logger.error(message);
+      process.exit(1);
+    }
+
+    globalConfig = getGlobalConfig(aiType);
+    isGlobal = true;
+
+    // Resolve target path
+    if (options.path) {
+      // Custom path provided
+      targetDir = expandHomePath(options.path);
+    } else {
+      // Prompt with default
+      const defaultPath = getDefaultGlobalPath(aiType);
+      const response = await prompts({
+        type: 'text',
+        name: 'path',
+        message: 'Global installation path:',
+        initial: defaultPath || '',
+      });
+
+      if (!response.path) {
+        logger.warn('Installation cancelled');
+        return;
+      }
+
+      targetDir = expandHomePath(response.path);
+    }
+
+    // Ensure target directory exists
+    await mkdir(targetDir, { recursive: true });
+
+    logger.info(`Installing globally to: ${chalk.cyan(targetDir)}`);
+  }
+
   logger.info(`Installing for: ${chalk.cyan(getAITypeDescription(aiType))}`);
 
   const spinner = ora('Installing files...').start();
-  const cwd = process.cwd();
   let copiedFolders: string[] = [];
   let usedGitHub = false;
 
   try {
     // Try GitHub download first (unless offline mode)
     if (!options.offline) {
-      const githubResult = await tryGitHubInstall(cwd, aiType, spinner);
+      const githubResult = await tryGitHubInstall(targetDir, aiType, spinner, isGlobal);
       if (githubResult) {
         copiedFolders = githubResult;
         usedGitHub = true;
@@ -143,17 +306,44 @@ export async function initCommand(options: InitOptions): Promise<void> {
     // Fall back to bundled assets if GitHub failed or offline mode
     if (!usedGitHub) {
       spinner.text = 'Installing from bundled assets...';
-      copiedFolders = await copyFolders(ASSETS_DIR, cwd, aiType);
+      if (isGlobal) {
+        copiedFolders = await copyFoldersGlobal(ASSETS_DIR, targetDir, aiType);
+      } else {
+        copiedFolders = await copyFolders(ASSETS_DIR, targetDir, aiType);
+      }
+    }
+
+    // Post-install transformations for global mode
+    if (isGlobal && globalConfig) {
+      spinner.text = 'Configuring global skill...';
+
+      // Find the skill markdown file and transform paths
+      const skillEntryPath = join(targetDir, globalConfig.skillEntryFile);
+
+      // First try to find and rename the workflow file
+      await renameToSkillEntry(targetDir, globalConfig);
+
+      // Add YAML frontmatter if needed
+      if (globalConfig.yamlFrontmatter) {
+        await ensureYamlFrontmatter(skillEntryPath);
+      }
+
+      // Transform paths from local to global
+      await transformPathsToGlobal(skillEntryPath, targetDir);
     }
 
     spinner.succeed(usedGitHub ? 'Installed from GitHub release!' : 'Installed from bundled assets!');
 
     // Summary
     console.log();
-    logger.info('Installed folders:');
-    copiedFolders.forEach(folder => {
-      console.log(`  ${chalk.green('+')} ${folder}`);
-    });
+    if (isGlobal) {
+      logger.info(`Installed to: ${chalk.green(targetDir)}`);
+    } else {
+      logger.info('Installed folders:');
+      copiedFolders.forEach(folder => {
+        console.log(`  ${chalk.green('+')} ${folder}`);
+      });
+    }
 
     console.log();
     logger.success('UI/UX Pro Max installed successfully!');
@@ -163,6 +353,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
     console.log(chalk.bold('Next steps:'));
     console.log(chalk.dim('  1. Restart your AI coding assistant'));
     console.log(chalk.dim('  2. Try: "Build a landing page for a SaaS product"'));
+    if (isGlobal) {
+      console.log(chalk.dim('  3. The skill is now available in all your projects'));
+    }
     console.log();
   } catch (error) {
     spinner.fail('Installation failed');

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -92,20 +92,19 @@ async function ensureYamlFrontmatter(filePath: string): Promise<void> {
 }
 
 /**
- * Transform paths in skill files from local to global
- * e.g., .shared/ui-ux-pro-max/ -> ~/.gemini/antigravity/skills/ui-ux-pro-max/
+ * Transform paths in skill files from local relative to global relative
+ * For global install, scripts/data are colocated, so we use ./scripts/ instead of ../../.shared/...
  */
-async function transformPathsToGlobal(filePath: string, globalBasePath: string): Promise<void> {
+async function transformPathsForGlobal(filePath: string): Promise<void> {
   try {
     let content = await readFile(filePath, 'utf-8');
 
-    // Replace .shared/ui-ux-pro-max/ with global path
-    const globalPath = globalBasePath.replace(homedir(), '~');
-    content = content.replace(/\.shared\/ui-ux-pro-max\//g, `${globalPath}/`);
+    // Replace relative paths like ../../.shared/ui-ux-pro-max/scripts/ with ./scripts/
+    // This works because in global install, scripts and data are in the same directory as SKILL.md
+    content = content.replace(/\.\.\/\.\.\/\.shared\/ui-ux-pro-max\//g, './');
 
-    // Also update relative script paths in Python commands
-    // e.g., python3 .shared/ui-ux-pro-max/scripts/ -> python3 ~/.../scripts/
-    content = content.replace(/python3?\s+\.shared\/ui-ux-pro-max\//g, `python3 ${globalPath}/`);
+    // Also handle any direct .shared/ references
+    content = content.replace(/\.shared\/ui-ux-pro-max\//g, './');
 
     await writeFile(filePath, content, 'utf-8');
   } catch {
@@ -328,8 +327,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
         await ensureYamlFrontmatter(skillEntryPath);
       }
 
-      // Transform paths from local to global
-      await transformPathsToGlobal(skillEntryPath, targetDir);
+      // Transform paths from local relative to global relative
+      await transformPathsForGlobal(skillEntryPath);
     }
 
     spinner.succeed(usedGitHub ? 'Installed from GitHub release!' : 'Installed from bundled assets!');

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -1,0 +1,136 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import chalk from 'chalk';
+import ora from 'ora';
+import prompts from 'prompts';
+import type { AIType } from '../types/index.js';
+import { AI_TYPES, AI_FOLDERS, GLOBAL_PATHS, GLOBAL_UNSUPPORTED_MESSAGES } from '../types/index.js';
+import { getAITypeDescription } from '../utils/detect.js';
+import { logger } from '../utils/logger.js';
+
+interface UninstallOptions {
+    ai?: AIType;
+    global?: boolean;
+    path?: string;
+    force?: boolean;
+}
+
+/**
+ * Resolve ~ to home directory in path
+ */
+function expandHomePath(path: string): string {
+    if (path.startsWith('~')) {
+        return join(homedir(), path.slice(1));
+    }
+    return path;
+}
+
+/**
+ * Get the default global path for a provider
+ */
+function getDefaultGlobalPath(aiType: AIType): string | null {
+    if (aiType === 'all') return null;
+    const config = GLOBAL_PATHS[aiType];
+    if (!config) return null;
+    return expandHomePath(config.path);
+}
+
+export async function uninstallCommand(options: UninstallOptions): Promise<void> {
+    logger.title('UI/UX Pro Max Uninstaller');
+
+    let aiType = options.ai;
+
+    // Prompt for AI type if not provided
+    if (!aiType) {
+        const response = await prompts({
+            type: 'select',
+            name: 'aiType',
+            message: 'Select AI assistant to uninstall from:',
+            choices: AI_TYPES.filter(t => t !== 'all').map(type => ({
+                title: getAITypeDescription(type),
+                value: type,
+            })),
+        });
+
+        if (!response.aiType) {
+            logger.warn('Uninstall cancelled');
+            return;
+        }
+
+        aiType = response.aiType as AIType;
+    }
+
+    if (aiType === 'all') {
+        logger.error('Uninstall with --ai all is not supported. Please specify a single provider.');
+        process.exit(1);
+    }
+
+    let targetDir: string;
+    let foldersToRemove: string[];
+
+    if (options.global) {
+        // Global uninstall
+        const config = GLOBAL_PATHS[aiType];
+
+        if (config === null) {
+            const message = GLOBAL_UNSUPPORTED_MESSAGES[aiType] ||
+                `${aiType} does not support global installation.`;
+            logger.error(message);
+            process.exit(1);
+        }
+
+        if (options.path) {
+            targetDir = expandHomePath(options.path);
+        } else {
+            targetDir = getDefaultGlobalPath(aiType) || '';
+        }
+
+        if (!targetDir) {
+            logger.error('Could not determine global path for ' + aiType);
+            process.exit(1);
+        }
+
+        foldersToRemove = [targetDir];
+        logger.info(`Uninstalling from global path: ${chalk.cyan(targetDir)}`);
+    } else {
+        // Local uninstall
+        targetDir = process.cwd();
+        foldersToRemove = AI_FOLDERS[aiType].map(folder => join(targetDir, folder));
+        logger.info(`Uninstalling from: ${chalk.cyan(targetDir)}`);
+    }
+
+    // Confirm before proceeding (unless --force)
+    if (!options.force) {
+        const response = await prompts({
+            type: 'confirm',
+            name: 'confirm',
+            message: `This will remove:\n${foldersToRemove.map(f => `  - ${f}`).join('\n')}\n\nContinue?`,
+            initial: false,
+        });
+
+        if (!response.confirm) {
+            logger.warn('Uninstall cancelled');
+            return;
+        }
+    }
+
+    const spinner = ora('Removing files...').start();
+
+    try {
+        for (const folder of foldersToRemove) {
+            await rm(folder, { recursive: true, force: true });
+        }
+
+        spinner.succeed('Files removed!');
+        console.log();
+        logger.success('UI/UX Pro Max uninstalled successfully!');
+        console.log();
+    } catch (error) {
+        spinner.fail('Uninstall failed');
+        if (error instanceof Error) {
+            logger.error(error.message);
+        }
+        process.exit(1);
+    }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'path';
 import { initCommand } from './commands/init.js';
 import { versionsCommand } from './commands/versions.js';
 import { updateCommand } from './commands/update.js';
+import { uninstallCommand } from './commands/uninstall.js';
 import type { AIType } from './types/index.js';
 import { AI_TYPES } from './types/index.js';
 
@@ -23,20 +24,28 @@ program
 
 program
   .command('init')
-  .description('Install UI/UX Pro Max skill to current project')
+  .description('Install UI/UX Pro Max skill to current project or global directory')
   .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
   .option('-f, --force', 'Overwrite existing files')
   .option('-o, --offline', 'Skip GitHub download, use bundled assets only')
+  .option('-g, --global', 'Install to global skills directory instead of local project')
+  .option('-p, --path <dir>', 'Custom installation path (only with --global)')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
       console.error(`Invalid AI type: ${options.ai}`);
       console.error(`Valid types: ${AI_TYPES.join(', ')}`);
       process.exit(1);
     }
+    if (options.path && !options.global) {
+      console.error('The --path option can only be used with --global');
+      process.exit(1);
+    }
     await initCommand({
       ai: options.ai as AIType | undefined,
       force: options.force,
       offline: options.offline,
+      global: options.global,
+      path: options.path,
     });
   });
 
@@ -57,6 +66,31 @@ program
     }
     await updateCommand({
       ai: options.ai as AIType | undefined,
+    });
+  });
+
+program
+  .command('uninstall')
+  .description('Uninstall UI/UX Pro Max skill')
+  .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
+  .option('-g, --global', 'Uninstall from global skills directory')
+  .option('-p, --path <dir>', 'Custom path to uninstall from (only with --global)')
+  .option('-f, --force', 'Skip confirmation prompt')
+  .action(async (options) => {
+    if (options.ai && !AI_TYPES.includes(options.ai)) {
+      console.error(`Invalid AI type: ${options.ai}`);
+      console.error(`Valid types: ${AI_TYPES.join(', ')}`);
+      process.exit(1);
+    }
+    if (options.path && !options.global) {
+      console.error('The --path option can only be used with --global');
+      process.exit(1);
+    }
+    await uninstallCommand({
+      ai: options.ai as AIType | undefined,
+      global: options.global,
+      path: options.path,
+      force: options.force,
     });
   });
 

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -37,3 +37,95 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   opencode: ['.opencode', '.shared'],
   continue: ['.continue'],
 };
+
+/**
+ * Configuration for global (user-level) skill installation paths.
+ * - path: Template path with ~ for home directory
+ * - format: How the skill should be structured
+ * - yamlFrontmatter: Whether SKILL.md needs YAML frontmatter
+ * - skillEntryFile: The expected entry file name for the skill
+ */
+export interface GlobalPathConfig {
+  path: string;
+  format: 'skill_folder' | 'prompt_file' | 'markdown';
+  yamlFrontmatter: boolean;
+  skillEntryFile: string;
+}
+
+/**
+ * Global installation paths for each AI provider.
+ * null = provider uses UI-managed global settings (not supported)
+ */
+export const GLOBAL_PATHS: Record<Exclude<AIType, 'all'>, GlobalPathConfig | null> = {
+  // File-based global paths (supported)
+  claude: {
+    path: '~/.claude/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  antigravity: {
+    path: '~/.gemini/antigravity/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  codex: {
+    path: '~/.codex/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  gemini: {
+    path: '~/.gemini/extensions/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  trae: {
+    path: '~/.trae/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  opencode: {
+    path: '~/.config/opencode/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: true,
+    skillEntryFile: 'SKILL.md',
+  },
+  continue: {
+    path: '~/.continue/prompts/ui-ux-pro-max',
+    format: 'prompt_file',
+    yamlFrontmatter: true,
+    skillEntryFile: 'ui-ux-pro-max.prompt',
+  },
+  qoder: {
+    path: '~/.qoder/rules/ui-ux-pro-max',
+    format: 'markdown',
+    yamlFrontmatter: false,
+    skillEntryFile: 'ui-ux-pro-max.md',
+  },
+  kiro: {
+    path: '~/.kiro/skills/ui-ux-pro-max',
+    format: 'skill_folder',
+    yamlFrontmatter: false,
+    skillEntryFile: 'ui-ux-pro-max.md',
+  },
+
+  // UI-managed global settings (not supported for --global flag)
+  cursor: null,   // Uses Cursor Settings UI
+  windsurf: null, // Uses Windsurf Settings UI  
+  copilot: null,  // Uses VS Code settings.json
+  roocode: null,  // Uses VS Code internal storage
+};
+
+/**
+ * Error messages for providers that don't support global installation
+ */
+export const GLOBAL_UNSUPPORTED_MESSAGES: Record<string, string> = {
+  cursor: 'Cursor manages global rules through its Settings UI. Use local install: uipro init --ai cursor',
+  windsurf: 'Windsurf manages global rules through its Settings UI. Use local install: uipro init --ai windsurf',
+  copilot: 'GitHub Copilot uses VS Code settings for global config. Use local install: uipro init --ai copilot',
+  roocode: 'Roo Code uses VS Code internal storage. Use local install: uipro init --ai roocode',
+};

--- a/cli/src/utils/extract.ts
+++ b/cli/src/utils/extract.ts
@@ -10,6 +10,26 @@ const execAsync = promisify(exec);
 
 const EXCLUDED_FILES = ['settings.local.json'];
 
+/**
+ * Mapping from AI type to the skill source folder in the repo
+ * For global install, we need to copy from the correct source location
+ */
+const GLOBAL_SOURCE_MAPPING: Record<Exclude<AIType, 'all'>, { skillFolder: string; sharedFolder?: string }> = {
+  claude: { skillFolder: '.claude/skills/ui-ux-pro-max' },
+  antigravity: { skillFolder: '.agent/workflows', sharedFolder: '.shared/ui-ux-pro-max' },
+  cursor: { skillFolder: '.cursor/commands', sharedFolder: '.shared/ui-ux-pro-max' },
+  windsurf: { skillFolder: '.windsurf/workflows', sharedFolder: '.shared/ui-ux-pro-max' },
+  copilot: { skillFolder: '.github/prompts', sharedFolder: '.shared/ui-ux-pro-max' },
+  kiro: { skillFolder: '.kiro/steering', sharedFolder: '.shared/ui-ux-pro-max' },
+  codex: { skillFolder: '.codex/skills/ui-ux-pro-max' },
+  roocode: { skillFolder: '.roo/rules', sharedFolder: '.shared/ui-ux-pro-max' },
+  qoder: { skillFolder: '.qoder/skills', sharedFolder: '.shared/ui-ux-pro-max' },
+  gemini: { skillFolder: '.gemini/skills/ui-ux-pro-max', sharedFolder: '.shared/ui-ux-pro-max' },
+  trae: { skillFolder: '.trae/skills/ui-ux-pro-max', sharedFolder: '.shared/ui-ux-pro-max' },
+  opencode: { skillFolder: '.opencode/skills/ui-ux-pro-max', sharedFolder: '.shared/ui-ux-pro-max' },
+  continue: { skillFolder: '.continue/skills/ui-ux-pro-max' },
+};
+
 export async function extractZip(zipPath: string, destDir: string): Promise<void> {
   try {
     const isWindows = process.platform === 'win32';
@@ -32,6 +52,9 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Copy folders for local (per-project) installation
+ */
 export async function copyFolders(
   sourceDir: string,
   targetDir: string,
@@ -87,6 +110,70 @@ export async function copyFolders(
   return copiedFolders;
 }
 
+/**
+ * Copy folders for global installation
+ * This copies the skill files and scripts into a single unified directory
+ */
+export async function copyFoldersGlobal(
+  sourceDir: string,
+  targetDir: string,
+  aiType: AIType
+): Promise<string[]> {
+  if (aiType === 'all') {
+    throw new Error('Global installation is not supported with --ai all');
+  }
+
+  const copiedItems: string[] = [];
+  const mapping = GLOBAL_SOURCE_MAPPING[aiType];
+
+  // Ensure target directory exists
+  await mkdir(targetDir, { recursive: true });
+
+  // Filter function to exclude certain files
+  const filterFn = (src: string): boolean => {
+    const fileName = basename(src);
+    return !EXCLUDED_FILES.includes(fileName);
+  };
+
+  // Copy the main skill/workflow file(s)
+  const skillSourcePath = join(sourceDir, mapping.skillFolder);
+  if (await exists(skillSourcePath)) {
+    try {
+      await cp(skillSourcePath, targetDir, { recursive: true, filter: filterFn });
+      copiedItems.push(mapping.skillFolder);
+    } catch (error) {
+      // Try shell fallback
+      if (process.platform === 'win32') {
+        await execAsync(`xcopy "${skillSourcePath}" "${targetDir}" /E /I /Y`);
+      } else {
+        await execAsync(`cp -r "${skillSourcePath}/." "${targetDir}"`);
+      }
+      copiedItems.push(mapping.skillFolder);
+    }
+  }
+
+  // Copy the shared folder contents (scripts, data) if it exists
+  if (mapping.sharedFolder) {
+    const sharedSourcePath = join(sourceDir, mapping.sharedFolder);
+    if (await exists(sharedSourcePath)) {
+      try {
+        await cp(sharedSourcePath, targetDir, { recursive: true, filter: filterFn });
+        copiedItems.push(mapping.sharedFolder);
+      } catch {
+        // Try shell fallback
+        if (process.platform === 'win32') {
+          await execAsync(`xcopy "${sharedSourcePath}" "${targetDir}" /E /I /Y`);
+        } else {
+          await execAsync(`cp -r "${sharedSourcePath}/." "${targetDir}"`);
+        }
+        copiedItems.push(mapping.sharedFolder);
+      }
+    }
+  }
+
+  return copiedItems;
+}
+
 export async function cleanup(tempDir: string): Promise<void> {
   try {
     await rm(tempDir, { recursive: true, force: true });
@@ -125,7 +212,8 @@ async function findExtractedRoot(tempDir: string): Promise<string> {
 export async function installFromZip(
   zipPath: string,
   targetDir: string,
-  aiType: AIType
+  aiType: AIType,
+  isGlobal: boolean = false
 ): Promise<{ copiedFolders: string[]; tempDir: string }> {
   // Create temp directory
   const tempDir = await createTempDir();
@@ -138,7 +226,9 @@ export async function installFromZip(
     const extractedRoot = await findExtractedRoot(tempDir);
 
     // Copy folders from extracted content to target
-    const copiedFolders = await copyFolders(extractedRoot, targetDir, aiType);
+    const copiedFolders = isGlobal
+      ? await copyFoldersGlobal(extractedRoot, targetDir, aiType)
+      : await copyFolders(extractedRoot, targetDir, aiType);
 
     return { copiedFolders, tempDir };
   } catch (error) {

--- a/cli/src/utils/extract.ts
+++ b/cli/src/utils/extract.ts
@@ -135,39 +135,48 @@ export async function copyFoldersGlobal(
     return !EXCLUDED_FILES.includes(fileName);
   };
 
+  /**
+   * Copy contents of a source directory into target directory
+   * This iterates over items in the source and copies each one
+   */
+  async function copyDirectoryContents(source: string, target: string): Promise<void> {
+    const entries = await readdir(source, { withFileTypes: true });
+    for (const entry of entries) {
+      const srcPath = join(source, entry.name);
+      const destPath = join(target, entry.name);
+
+      if (!filterFn(srcPath)) continue;
+
+      try {
+        await cp(srcPath, destPath, { recursive: true, filter: filterFn });
+      } catch {
+        // Shell fallback
+        if (process.platform === 'win32') {
+          if (entry.isDirectory()) {
+            await execAsync(`xcopy "${srcPath}" "${destPath}\\" /E /I /Y`);
+          } else {
+            await execAsync(`copy /Y "${srcPath}" "${destPath}"`);
+          }
+        } else {
+          await execAsync(`cp -r "${srcPath}" "${destPath}"`);
+        }
+      }
+    }
+  }
+
   // Copy the main skill/workflow file(s)
   const skillSourcePath = join(sourceDir, mapping.skillFolder);
   if (await exists(skillSourcePath)) {
-    try {
-      await cp(skillSourcePath, targetDir, { recursive: true, filter: filterFn });
-      copiedItems.push(mapping.skillFolder);
-    } catch (error) {
-      // Try shell fallback
-      if (process.platform === 'win32') {
-        await execAsync(`xcopy "${skillSourcePath}" "${targetDir}" /E /I /Y`);
-      } else {
-        await execAsync(`cp -r "${skillSourcePath}/." "${targetDir}"`);
-      }
-      copiedItems.push(mapping.skillFolder);
-    }
+    await copyDirectoryContents(skillSourcePath, targetDir);
+    copiedItems.push(mapping.skillFolder);
   }
 
   // Copy the shared folder contents (scripts, data) if it exists
   if (mapping.sharedFolder) {
     const sharedSourcePath = join(sourceDir, mapping.sharedFolder);
     if (await exists(sharedSourcePath)) {
-      try {
-        await cp(sharedSourcePath, targetDir, { recursive: true, filter: filterFn });
-        copiedItems.push(mapping.sharedFolder);
-      } catch {
-        // Try shell fallback
-        if (process.platform === 'win32') {
-          await execAsync(`xcopy "${sharedSourcePath}" "${targetDir}" /E /I /Y`);
-        } else {
-          await execAsync(`cp -r "${sharedSourcePath}/." "${targetDir}"`);
-        }
-        copiedItems.push(mapping.sharedFolder);
-      }
+      await copyDirectoryContents(sharedSourcePath, targetDir);
+      copiedItems.push(mapping.sharedFolder);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds `--global` and `--path` flags to `uipro init` to support installing skills to the user's global skills directory instead of per-project installation.

## New Commands

```bash
# Install to global skills directory (with interactive path prompt)
uipro init --ai antigravity --global

# Install to custom global path
uipro init --ai antigravity --global --path "~/my-skills/"

# Uninstall from global
uipro uninstall --ai antigravity --global
```

## Supported Providers (9)

| Provider | Global Path |
|----------|-------------|
| claude | `~/.claude/skills/ui-ux-pro-max` |
| antigravity | `~/.gemini/antigravity/skills/ui-ux-pro-max` |
| codex | `~/.codex/skills/ui-ux-pro-max` |
| gemini | `~/.gemini/extensions/ui-ux-pro-max` |
| trae | `~/.trae/skills/ui-ux-pro-max` |
| opencode | `~/.config/opencode/skills/ui-ux-pro-max` |
| continue | `~/.continue/prompts/ui-ux-pro-max` |
| qoder | `~/.qoder/rules/ui-ux-pro-max` |
| kiro | `~/.kiro/skills/ui-ux-pro-max` |

## UI-Managed Providers (4)

These show helpful error messages directing users to use local install:
- cursor, windsurf, copilot, roocode

## Other Changes

- Added `uninstall` command
- Switched build from bun to esbuild for better Windows compatibility