### PR TITLE
feat(cli): add interactive multi-select for init command

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,9 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "uxpro-cli",
       "dependencies": {
+        "@clack/prompts": "^0.9.1",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "ora": "^8.1.1",
@@ -18,6 +20,10 @@
     },
   },
   "packages": {
+    "@clack/core": ["@clack/core@0.4.1", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA=="],
+
+    "@clack/prompts": ["@clack/prompts@0.9.1", "", { "dependencies": { "@clack/core": "0.4.1", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg=="],
+
     "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
 
     "@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
@@ -53,6 +59,8 @@
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,6 +34,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@clack/prompts": "^0.9.1",
     "commander": "^12.1.0",
     "chalk": "^5.3.0",
     "ora": "^8.1.1",

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -2,7 +2,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import ora from 'ora';
-import prompts from 'prompts';
+import * as p from '@clack/prompts';
 import type { AIType } from '../types/index.js';
 import { AI_TYPES } from '../types/index.js';
 import { copyFolders, installFromZip, createTempDir, cleanup } from '../utils/extract.js';
@@ -111,96 +111,106 @@ async function templateInstall(
 }
 
 export async function initCommand(options: InitOptions): Promise<void> {
-  logger.title('UI/UX Pro Max Installer');
+  console.log();
+  p.intro(chalk.bgCyan.black(' UI/UX Pro Max Installer '));
 
-  let aiType = options.ai;
+  let selectedTypes: AIType[] = [];
 
-  // Auto-detect or prompt for AI type
-  if (!aiType) {
-    const { detected, suggested } = detectAIType();
+  // If --ai flag is provided, use that single type
+  if (options.ai) {
+    selectedTypes = [options.ai];
+    p.log.info(`Installing for: ${chalk.cyan(getAITypeDescription(options.ai))}`);
+  } else {
+    // Auto-detect installed AI assistants
+    const { detected } = detectAIType();
 
     if (detected.length > 0) {
-      logger.info(`Detected: ${detected.map(t => chalk.cyan(t)).join(', ')}`);
+      p.log.info(`Detected: ${detected.map(t => chalk.cyan(getAITypeDescription(t))).join(', ')}`);
     }
 
-    const response = await prompts({
-      type: 'select',
-      name: 'aiType',
-      message: 'Select AI assistant to install for:',
-      choices: AI_TYPES.map(type => ({
-        title: getAITypeDescription(type),
+    // Filter out 'all' from AI_TYPES for multi-select
+    const selectableTypes = AI_TYPES.filter(t => t !== 'all');
+
+    // Multi-select prompt
+    const selected = await p.multiselect({
+      message: 'Select AI assistants to install for:',
+      options: selectableTypes.map(type => ({
         value: type,
+        label: getAITypeDescription(type),
+        hint: detected.includes(type) ? 'detected' : undefined,
       })),
-      initial: suggested ? AI_TYPES.indexOf(suggested) : 0,
+      initialValues: detected.length > 0 ? detected : ['claude'],
+      required: true,
     });
 
-    if (!response.aiType) {
-      logger.warn('Installation cancelled');
-      return;
+    if (p.isCancel(selected)) {
+      p.cancel('Installation cancelled');
+      process.exit(0);
     }
 
-    aiType = response.aiType as AIType;
+    selectedTypes = selected as AIType[];
   }
 
-  logger.info(`Installing for: ${chalk.cyan(getAITypeDescription(aiType))}`);
+  if (selectedTypes.length === 0) {
+    p.log.error('No AI assistants selected');
+    process.exit(1);
+  }
 
-  const spinner = ora('Installing files...').start();
+  const spinner = p.spinner();
+  spinner.start('Installing skill files...');
+
   const cwd = process.cwd();
-  let copiedFolders: string[] = [];
-  let installMethod = 'template';
+  const allCopiedFolders: string[] = [];
 
   try {
-    // Use legacy ZIP-based install if --legacy flag is set
-    if (options.legacy) {
-      // Try GitHub download first (unless offline mode)
-      if (!options.offline) {
-        const githubResult = await tryGitHubInstall(cwd, aiType, spinner);
-        if (githubResult) {
-          copiedFolders = githubResult;
-          installMethod = 'github';
+    for (const aiType of selectedTypes) {
+      // Use legacy ZIP-based install if --legacy flag is set
+      if (options.legacy) {
+        const oraSpinner = ora().start();
+        // Try GitHub download first (unless offline mode)
+        if (!options.offline) {
+          const githubResult = await tryGitHubInstall(cwd, aiType, oraSpinner);
+          if (githubResult) {
+            allCopiedFolders.push(...githubResult);
+            oraSpinner.stop();
+            continue;
+          }
         }
+        // Fall back to bundled assets if GitHub failed or offline mode
+        const folders = await copyFolders(ASSETS_DIR, cwd, aiType);
+        allCopiedFolders.push(...folders);
+        oraSpinner.stop();
+      } else {
+        // Use new template-based generation (default)
+        const folders = await generatePlatformFiles(cwd, aiType);
+        allCopiedFolders.push(...folders);
       }
-
-      // Fall back to bundled assets if GitHub failed or offline mode
-      if (installMethod !== 'github') {
-        spinner.text = 'Installing from bundled assets...';
-        copiedFolders = await copyFolders(ASSETS_DIR, cwd, aiType);
-        installMethod = 'bundled';
-      }
-    } else {
-      // Use new template-based generation (default)
-      copiedFolders = await templateInstall(cwd, aiType, spinner);
-      installMethod = 'template';
     }
 
-    const methodMessage = {
-      github: 'Installed from GitHub release!',
-      bundled: 'Installed from bundled assets!',
-      template: 'Generated from templates!',
-    }[installMethod];
+    spinner.stop('Installation complete');
 
-    spinner.succeed(methodMessage);
-
-    // Summary
-    console.log();
-    logger.info('Installed folders:');
-    copiedFolders.forEach(folder => {
-      console.log(`  ${chalk.green('+')} ${folder}`);
-    });
+    // Summary - deduplicate folders
+    const uniqueFolders = [...new Set(allCopiedFolders)];
 
     console.log();
-    logger.success('UI/UX Pro Max installed successfully!');
+    p.log.success(`Installed for ${chalk.cyan(selectedTypes.length)} AI assistant(s):`);
+    for (const aiType of selectedTypes) {
+      p.log.message(`  ${chalk.green('✓')} ${getAITypeDescription(aiType)}`);
+    }
 
-    // Next steps
     console.log();
-    console.log(chalk.bold('Next steps:'));
-    console.log(chalk.dim('  1. Restart your AI coding assistant'));
-    console.log(chalk.dim('  2. Try: "Build a landing page for a SaaS product"'));
+    p.log.step('Created folders:');
+    for (const folder of uniqueFolders) {
+      p.log.message(`  ${chalk.dim(folder)}`);
+    }
+
     console.log();
+    p.outro(chalk.green('Done! Restart your AI coding assistant to use the skill.'));
+
   } catch (error) {
-    spinner.fail('Installation failed');
+    spinner.stop('Installation failed');
     if (error instanceof Error) {
-      logger.error(error.message);
+      p.log.error(error.message);
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Replace single-select prompt with multi-select UI using `@clack/prompts`, allowing users to install for multiple AI assistants in one command.

## Changes

- Add `@clack/prompts` dependency for modern CLI UI
- Replace `prompts` single-select with `p.multiselect()`
- Show `(detected)` hints next to auto-detected AI assistants
- Pre-select detected agents by default
- Install for multiple selected agents in one run

## Before
```
? Select AI assistant to install for: (Use arrow keys)
❯ Claude Code
Cursor
Windsurf
```

## After
```
◆ Select AI assistants to install for:
│ ◼ Claude Code      (detected)
│ ◼ Cursor           (detected)
│ ◻ Windsurf
│ ◻ GitHub Copilot
```

## Testing

```bash
cd cli && bun install && bun run build
./dist/index.js init