### PR TITLE
feat: add kilocode platform configuration and detection support

### DIFF
--- a/cli/assets/templates/platforms/kilocode.json
+++ b/cli/assets/templates/platforms/kilocode.json
@@ -1,0 +1,21 @@
+{
+  "platform": "kilocode",
+  "displayName": "Kilo Code",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".kilocode",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 56 font pairings, 25 charts, 13 stacks. Actions: plan, build, create, design, implement, review, fix, improve UI/UX code. Projects: website, landing page, dashboard, e-commerce, SaaS, portfolio, mobile app."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "UI/UX Pro Max",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'all';
+export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'kilocode' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'all';
 
 export type InstallType = 'full' | 'reference';
 
@@ -41,7 +41,7 @@ export interface PlatformConfig {
   skillOrWorkflow: string;
 }
 
-export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'all'];
+export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'kilocode', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'all'];
 
 // Legacy folder mapping for backward compatibility with ZIP-based installs
 export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
@@ -51,6 +51,7 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   antigravity: ['.agent', '.shared'],
   copilot: ['.github', '.shared'],
   kiro: ['.kiro', '.shared'],
+  kilocode: ['.kilocode'],
   codex: ['.codex'],
   roocode: ['.roo', '.shared'],
   qoder: ['.qoder', '.shared'],

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -28,6 +28,9 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.kiro'))) {
     detected.push('kiro');
   }
+  if (existsSync(join(cwd, '.kilocode'))) {
+    detected.push('kilocode');
+  }
   if (existsSync(join(cwd, '.codex'))) {
     detected.push('codex');
   }
@@ -78,6 +81,8 @@ export function getAITypeDescription(aiType: AIType): string {
       return 'GitHub Copilot (.github/prompts/ + .shared/)';
     case 'kiro':
       return 'Kiro (.kiro/steering/ + .shared/)';
+    case 'kilocode':
+      return 'Kilo Code (.kilocode/skills/)';
     case 'codex':
       return 'Codex (.codex/skills/)';
     case 'roocode':

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -33,6 +33,7 @@ const AI_TO_PLATFORM: Record<string, string> = {
   antigravity: 'agent',
   copilot: 'copilot',
   kiro: 'kiro',
+  kilocode: 'kilocode',
   opencode: 'opencode',
   roocode: 'roocode',
   codex: 'codex',

--- a/src/ui-ux-pro-max/templates/platforms/kilocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/kilocode.json
@@ -1,0 +1,21 @@
+{
+  "platform": "kilocode",
+  "displayName": "Kilo Code",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".kilocode",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 56 font pairings, 25 charts, 13 stacks. Actions: plan, build, create, design, implement, review, fix, improve UI/UX code. Projects: website, landing page, dashboard, e-commerce, SaaS, portfolio, mobile app."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "UI/UX Pro Max",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}


### PR DESCRIPTION
Add support for Kilo Code AI assistant in the CLI installer, resolves https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/issues/89

## Changes

- Add `kilocode.json` platform config template
- Add `kilocode` to `AIType` union and `AI_TYPES` array
- Add `.kilocode` to `AI_FOLDERS` mapping
- Add Kilo Code detection in `detect.ts`
- Add description for Kilo Code in `getAITypeDescription()`

## Install Structure

Following the [Kilo Code skills specification](https://kilo.ai/docs/agent-behavior/skills):
```
.kilocode/
└── skills/
└─── ui-ux-pro-max/
├─── SKILL.md      # With YAML frontmatter (name, description)
├─── data/
└─── scripts/
```

## Usage

```bash
npx uipro-cli init --ai kilocode
```