### PR TITLE
fix: add plugin.json manifest for Claude Code skill loading

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "ui-ux-pro-max",
+  "version": "2.0.1",
+  "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, and shadcn/ui.",
+  "author": {
+    "name": "nextlevelbuilder"
+  },
+  "license": "MIT",
+  "keywords": ["ui", "ux", "design", "styles", "typography", "color-palette", "accessibility", "charts", "components"],
+  "skills": ["./.claude/skills/ui-ux-pro-max"]
+}


### PR DESCRIPTION
## Summary

- Add missing `plugin.json` file to `.claude-plugin/` directory
- Include full metadata (version, description, author, keywords) for consistency with `marketplace.json`

Fixes #123

## Problem

The plugin installs successfully via `/plugins install` but the skill is never loaded into Claude Code's prompt. This happens because:

- `marketplace.json` is only used for marketplace indexing/discovery
- `plugin.json` is required for runtime plugin loading

## Solution

Add `plugin.json` with:
- `name`: Plugin identifier
- `version`: Aligned with marketplace.json (2.0.1)
- `description`: Full plugin description
- `author`: Author information
- `license`: MIT
- `keywords`: Discovery tags
- `skills`: Path to skill directory (`./.claude/skills/ui-ux-pro-max`)

## Test Plan

- [ ] Install plugin via `/plugins install ui-ux-pro-max-skill`
- [ ] Restart Claude Code
- [ ] Verify skill appears in available skills list
- [ ] Invoke `/ui-ux-pro-max` and confirm it loads correctly

---

🤖 Generated with [Claude Code](https://claude.ai/code)