### PR TITLE
docs: update README, fix counts, change Windsurf to skill mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,15 @@
     "name": "nextlevelbuilder"
   },
   "metadata": {
-    "description": "UI/UX design intelligence skill with 50 styles, 21 palettes, 50 font pairings, 20 charts, and 9 stack guidelines",
-    "version": "2.0.1"
+    "description": "UI/UX design intelligence skill with 67 styles, 96 palettes, 57 font pairings, 25 charts, and 13 stack guidelines",
+    "version": "2.2.1"
   },
   "plugins": [
     {
       "name": "ui-ux-pro-max",
       "source": "./",
-      "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, and shadcn/ui.",
-      "version": "2.0.1",
+      "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and Jetpack Compose.",
+      "version": "2.2.1",
       "author": {
         "name": "nextlevelbuilder"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,19 +14,18 @@ python3 src/ui-ux-pro-max/scripts/search.py "<query>" --domain <domain> [-n <max
 
 **Domain search:**
 - `product` - Product type recommendations (SaaS, e-commerce, portfolio)
-- `style` - UI styles (glassmorphism, minimalism, brutalism)
+- `style` - UI styles (glassmorphism, minimalism, brutalism) + AI prompts and CSS keywords
 - `typography` - Font pairings with Google Fonts imports
 - `color` - Color palettes by product type
 - `landing` - Page structure and CTA strategies
 - `chart` - Chart types and library recommendations
 - `ux` - Best practices and anti-patterns
-- `prompt` - AI prompts and CSS keywords
 
 **Stack search:**
 ```bash
 python3 src/ui-ux-pro-max/scripts/search.py "<query>" --stack <stack>
 ```
-Available stacks: `html-tailwind` (default), `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
+Available stacks: `html-tailwind` (default), `react`, `nextjs`, `astro`, `vue`, `nuxtjs`, `nuxt-ui`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The flagship feature of v2.0 is the **Design System Generator** - an AI-powered 
 │     • Style recommendations (67 styles)                         │
 │     • Color palette selection (96 palettes)                     │
 │     • Landing page patterns (24 patterns)                       │
-│     • Typography pairing (56 font combinations)                 │
+│     • Typography pairing (57 font combinations)                 │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -144,10 +144,10 @@ Each rule includes:
 
 - **67 UI Styles** - Glassmorphism, Claymorphism, Minimalism, Brutalism, Neumorphism, Bento Grid, Dark Mode, AI-Native UI, and more
 - **96 Color Palettes** - Industry-specific palettes for SaaS, E-commerce, Healthcare, Fintech, Beauty, etc.
-- **56 Font Pairings** - Curated typography combinations with Google Fonts imports
+- **57 Font Pairings** - Curated typography combinations with Google Fonts imports
 - **25 Chart Types** - Recommendations for dashboards and analytics
 - **13 Tech Stacks** - React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, HTML+Tailwind, shadcn/ui, Jetpack Compose
-- **98 UX Guidelines** - Best practices, anti-patterns, and accessibility rules
+- **99 UX Guidelines** - Best practices, anti-patterns, and accessibility rules
 - **100 Reasoning Rules** - Industry-specific design system generation (NEW in v2.0)
 
 ### Available Styles (67)
@@ -309,7 +309,9 @@ winget install Python.Python.3.12
 
 ## Usage
 
-### Claude Code
+### Skill Mode (Auto-activate)
+
+**Supported:** Claude Code, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, OpenCode, Qoder, CodeBuddy
 
 The skill activates automatically when you request UI/UX work. Just chat naturally:
 
@@ -317,94 +319,16 @@ The skill activates automatically when you request UI/UX work. Just chat natural
 Build a landing page for my SaaS product
 ```
 
-### Cursor / Windsurf / Antigravity
+> **Trae**: Switch to **SOLO** mode first. The skill will activate for UI/UX requests.
+
+### Workflow Mode (Slash Command)
+
+**Supported:** Cursor, Kiro, GitHub Copilot, Roo Code
 
 Use the slash command to invoke the skill:
 
 ```
 /ui-ux-pro-max Build a landing page for my SaaS product
-```
-
-### Kiro
-
-Type `/` in chat to see available commands, then select `ui-ux-pro-max`:
-
-```
-/ui-ux-pro-max Build a landing page for my SaaS product
-```
-
-### GitHub Copilot
-
-In VS Code with Copilot, type `/` in chat to see available prompts, then select `ui-ux-pro-max`:
-
-```
-/ui-ux-pro-max Build a landing page for my SaaS product
-```
-
-### Codex CLI
-
-The skill activates automatically for UI/UX requests. You can also invoke it explicitly:
-
-```
-$ui-ux-pro-max Build a landing page for my SaaS product
-```
-
-### Continue
-
-The skill activates automatically for UI/UX requests once installed to `.continue/skills/`:
-
-```
-Build a landing page for my SaaS product
-```
-
-### Qoder
-
-The skill activates automatically when you request UI/UX work:
-
-```
-Build a landing page for my SaaS product
-```
-
-### Roo Code
-
-The skill activates automatically when you request UI/UX work:
-
-```
-Build a landing page for my SaaS product
-```
-
-### Gemini CLI
-
-The skill activates automatically when you request UI/UX work:
-
-```
-Build a landing page for my SaaS product
-```
-
-### Trae
-
-_Disclaimer: Trae skill is in beta. Please report any issues or feedback._
-
-To use Trae skill, you need to switch to **SOLO** mode. If your request is related to skills, skills will be used:
-
-```
-Build a landing page (frontend ONLY) for my SaaS product.
-```
-
-### OpenCode
-
-The skill activates automatically when you request UI/UX work:
-
-```
-Build a landing page for my SaaS product
-```
-
-### CodeBuddy
-
-The skill activates automatically when you request UI/UX work:
-
-```
-Build a landing page for my SaaS product
 ```
 
 ### Example Prompts

--- a/cli/assets/templates/platforms/agent.json
+++ b/cli/assets/templates/platforms/agent.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/claude.json
+++ b/cli/assets/templates/platforms/claude.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 56 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
   },
   "sections": {
     "quickReference": true
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codebuddy.json
+++ b/cli/assets/templates/platforms/codebuddy.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codex.json
+++ b/cli/assets/templates/platforms/codex.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/continue.json
+++ b/cli/assets/templates/platforms/continue.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/copilot.json
+++ b/cli/assets/templates/platforms/copilot.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/cursor.json
+++ b/cli/assets/templates/platforms/cursor.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/gemini.json
+++ b/cli/assets/templates/platforms/gemini.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/kiro.json
+++ b/cli/assets/templates/platforms/kiro.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/opencode.json
+++ b/cli/assets/templates/platforms/opencode.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/qoder.json
+++ b/cli/assets/templates/platforms/qoder.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/roocode.json
+++ b/cli/assets/templates/platforms/roocode.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/trae.json
+++ b/cli/assets/templates/platforms/trae.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/windsurf.json
+++ b/cli/assets/templates/platforms/windsurf.json
@@ -4,7 +4,7 @@
   "installType": "reference",
   "folderStructure": {
     "root": ".windsurf",
-    "skillPath": "workflows",
+    "skillPath": "skills",
     "filename": "ui-ux-pro-max.md"
   },
   "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
-  "skillOrWorkflow": "Workflow"
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
 }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uipro-cli",
-  "version": "2.1.3",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uipro-cli",
-      "version": "2.1.3",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {

--- a/src/ui-ux-pro-max/templates/platforms/agent.json
+++ b/src/ui-ux-pro-max/templates/platforms/agent.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/claude.json
+++ b/src/ui-ux-pro-max/templates/platforms/claude.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 56 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
   },
   "sections": {
     "quickReference": true
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/codebuddy.json
+++ b/src/ui-ux-pro-max/templates/platforms/codebuddy.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/codex.json
+++ b/src/ui-ux-pro-max/templates/platforms/codex.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/continue.json
+++ b/src/ui-ux-pro-max/templates/platforms/continue.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/copilot.json
+++ b/src/ui-ux-pro-max/templates/platforms/copilot.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/cursor.json
+++ b/src/ui-ux-pro-max/templates/platforms/cursor.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/gemini.json
+++ b/src/ui-ux-pro-max/templates/platforms/gemini.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/kiro.json
+++ b/src/ui-ux-pro-max/templates/platforms/kiro.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/opencode.json
+++ b/src/ui-ux-pro-max/templates/platforms/opencode.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/qoder.json
+++ b/src/ui-ux-pro-max/templates/platforms/qoder.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/roocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/roocode.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/trae.json
+++ b/src/ui-ux-pro-max/templates/platforms/trae.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/windsurf.json
+++ b/src/ui-ux-pro-max/templates/platforms/windsurf.json
@@ -4,7 +4,7 @@
   "installType": "reference",
   "folderStructure": {
     "root": ".windsurf",
-    "skillPath": "workflows",
+    "skillPath": "skills",
     "filename": "ui-ux-pro-max.md"
   },
   "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 56 font pairings, 98 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
-  "skillOrWorkflow": "Workflow"
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
 }


### PR DESCRIPTION
## Summary
- Remove Manual Installation section from README
- Add 67 styles table with # | Style | Best For format
- Update Supported Stacks table with all 13 stacks
- Simplify Usage section: group by Skill mode vs Workflow mode
- Fix counts: 57 font pairings (was 56), 99 UX guidelines (was 98)
- Change Windsurf from Workflow to Skill mode
- Update CLAUDE.md: remove prompt domain, add missing stacks
- Bump CLI version to 2.2.1, published to npm

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Check CLI install works: `npx uipro-cli init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)