### PR TITLE
fix: self-contained installation for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ winget install Python.Python.3.12
 
 ### Skill Mode (Auto-activate)
 
-**Supported:** Claude Code, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, OpenCode, Qoder, CodeBuddy
+**Supported:** Claude Code, Cursor, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, OpenCode, Qoder, CodeBuddy
 
 The skill activates automatically when you request UI/UX work. Just chat naturally:
 
@@ -323,7 +323,7 @@ Build a landing page for my SaaS product
 
 ### Workflow Mode (Slash Command)
 
-**Supported:** Cursor, Kiro, GitHub Copilot, Roo Code
+**Supported:** Kiro, GitHub Copilot, Roo Code
 
 Use the slash command to invoke the skill:
 

--- a/cli/assets/templates/platforms/copilot.json
+++ b/cli/assets/templates/platforms/copilot.json
@@ -1,13 +1,13 @@
 {
   "platform": "copilot",
   "displayName": "GitHub Copilot",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".github",
-    "skillPath": "prompts",
-    "filename": "ui-ux-pro-max.prompt.md"
+    "skillPath": "prompts/ui-ux-pro-max",
+    "filename": "PROMPT.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "prompts/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/cli/assets/templates/platforms/cursor.json
+++ b/cli/assets/templates/platforms/cursor.json
@@ -1,18 +1,18 @@
 {
   "platform": "cursor",
   "displayName": "Cursor",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".cursor",
-    "skillPath": "commands",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
   "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
-  "skillOrWorkflow": "Workflow"
+  "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/kiro.json
+++ b/cli/assets/templates/platforms/kiro.json
@@ -1,13 +1,13 @@
 {
   "platform": "kiro",
   "displayName": "Kiro",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".kiro",
-    "skillPath": "steering",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "steering/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "steering/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/cli/assets/templates/platforms/qoder.json
+++ b/cli/assets/templates/platforms/qoder.json
@@ -1,13 +1,13 @@
 {
   "platform": "qoder",
   "displayName": "Qoder",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".qoder",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
     "description": "UI/UX design intelligence with searchable database"

--- a/cli/assets/templates/platforms/roocode.json
+++ b/cli/assets/templates/platforms/roocode.json
@@ -1,13 +1,13 @@
 {
   "platform": "roocode",
   "displayName": "Roo Code",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".roo",
-    "skillPath": "commands",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/cli/assets/templates/platforms/windsurf.json
+++ b/cli/assets/templates/platforms/windsurf.json
@@ -1,13 +1,13 @@
 {
   "platform": "windsurf",
   "displayName": "Windsurf",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".windsurf",
-    "skillPath": "skills",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -69,23 +69,23 @@ export function getAITypeDescription(aiType: AIType): string {
     case 'claude':
       return 'Claude Code (.claude/skills/)';
     case 'cursor':
-      return 'Cursor (.cursor/commands/ + .shared/)';
+      return 'Cursor (.cursor/skills/)';
     case 'windsurf':
-      return 'Windsurf (.windsurf/skills/ + .shared/)';
+      return 'Windsurf (.windsurf/skills/)';
     case 'antigravity':
       return 'Antigravity (.agent/skills/)';
     case 'copilot':
-      return 'GitHub Copilot (.github/prompts/ + .shared/)';
+      return 'GitHub Copilot (.github/prompts/)';
     case 'kiro':
-      return 'Kiro (.kiro/steering/ + .shared/)';
+      return 'Kiro (.kiro/steering/)';
     case 'codex':
       return 'Codex (.codex/skills/)';
     case 'roocode':
-      return 'RooCode (.roo/commands/ + .shared/)';
+      return 'RooCode (.roo/skills/)';
     case 'qoder':
-      return 'Qoder (.qoder/rules/ + .shared/)';
+      return 'Qoder (.qoder/skills/)';
     case 'gemini':
-      return 'Gemini CLI (.gemini/skills/ + .shared/)';
+      return 'Gemini CLI (.gemini/skills/)';
     case 'trae':
       return 'Trae (.trae/skills/)';
     case 'opencode':

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -165,23 +165,8 @@ async function copyDataAndScripts(targetSkillDir: string): Promise<void> {
 }
 
 /**
- * Ensure .shared folder exists with data and scripts
- */
-async function ensureSharedExists(targetDir: string): Promise<boolean> {
-  const sharedDir = join(targetDir, '.shared', 'ui-ux-pro-max');
-
-  // Check if already exists
-  if (await exists(sharedDir)) {
-    return false; // Already exists, didn't create
-  }
-
-  await mkdir(sharedDir, { recursive: true });
-  await copyDataAndScripts(sharedDir);
-  return true; // Created new
-}
-
-/**
  * Generate platform files for a specific AI type
+ * All platforms use self-contained installation with data and scripts
  */
 export async function generatePlatformFiles(
   targetDir: string,
@@ -206,17 +191,8 @@ export async function generatePlatformFiles(
   await writeFile(skillFilePath, skillContent, 'utf-8');
   createdFolders.push(config.folderStructure.root);
 
-  // Handle data/scripts based on install type
-  if (config.installType === 'full') {
-    // Full install: copy data and scripts into the skill directory
-    await copyDataAndScripts(skillDir);
-  } else {
-    // Reference install: ensure .shared exists
-    const createdShared = await ensureSharedExists(targetDir);
-    if (createdShared) {
-      createdFolders.push('.shared');
-    }
-  }
+  // Copy data and scripts into the skill directory (self-contained)
+  await copyDataAndScripts(skillDir);
 
   return createdFolders;
 }

--- a/src/ui-ux-pro-max/templates/platforms/copilot.json
+++ b/src/ui-ux-pro-max/templates/platforms/copilot.json
@@ -1,13 +1,13 @@
 {
   "platform": "copilot",
   "displayName": "GitHub Copilot",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".github",
-    "skillPath": "prompts",
-    "filename": "ui-ux-pro-max.prompt.md"
+    "skillPath": "prompts/ui-ux-pro-max",
+    "filename": "PROMPT.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "prompts/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/src/ui-ux-pro-max/templates/platforms/cursor.json
+++ b/src/ui-ux-pro-max/templates/platforms/cursor.json
@@ -1,18 +1,18 @@
 {
   "platform": "cursor",
   "displayName": "Cursor",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".cursor",
-    "skillPath": "commands",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
   "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
-  "skillOrWorkflow": "Workflow"
+  "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/kiro.json
+++ b/src/ui-ux-pro-max/templates/platforms/kiro.json
@@ -1,13 +1,13 @@
 {
   "platform": "kiro",
   "displayName": "Kiro",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".kiro",
-    "skillPath": "steering",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "steering/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "steering/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/src/ui-ux-pro-max/templates/platforms/qoder.json
+++ b/src/ui-ux-pro-max/templates/platforms/qoder.json
@@ -1,13 +1,13 @@
 {
   "platform": "qoder",
   "displayName": "Qoder",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".qoder",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
     "description": "UI/UX design intelligence with searchable database"

--- a/src/ui-ux-pro-max/templates/platforms/roocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/roocode.json
@@ -1,13 +1,13 @@
 {
   "platform": "roocode",
   "displayName": "Roo Code",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".roo",
-    "skillPath": "commands",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false

--- a/src/ui-ux-pro-max/templates/platforms/windsurf.json
+++ b/src/ui-ux-pro-max/templates/platforms/windsurf.json
@@ -1,13 +1,13 @@
 {
   "platform": "windsurf",
   "displayName": "Windsurf",
-  "installType": "reference",
+  "installType": "full",
   "folderStructure": {
     "root": ".windsurf",
-    "skillPath": "skills",
-    "filename": "ui-ux-pro-max.md"
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
   },
-  "scriptPath": ".shared/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": null,
   "sections": {
     "quickReference": false


### PR DESCRIPTION
## Summary
- Remove `.shared` folder dependency - all platforms now self-contained
- Each platform installation includes its own `data/` and `scripts/`
- Update platform configs: `reference` → `full` install type
- Simplify `template.ts`: remove `ensureSharedExists` logic
- Update Cursor to Skill Mode (auto-activate)
- Update README to reflect Cursor in Skill Mode
- Bump CLI version to 2.2.2

## Problem
Users reported `search.py` not found in `.shared` folder after installation. This was caused by a bug where `ensureSharedExists()` would skip copying files if the folder already existed (even if empty or incomplete).

## Solution
All platforms now use self-contained installation - each gets its own copy of `data/` and `scripts/` inside the skill folder. No more shared dependencies.

## Test plan
- [x] Test CLI install for Cursor: `.cursor/skills/ui-ux-pro-max/` with data + scripts
- [x] Test CLI install for Windsurf: `.windsurf/skills/ui-ux-pro-max/` with data + scripts
- [x] Verify no `.shared` folder created
- [x] Verify `search.py` runs successfully
- [x] Published to npm as v2.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)