### PR TITLE
fix: Windows Unicode encoding error for emoji characters

### DIFF
--- a/cli/assets/scripts/search.py
+++ b/cli/assets/scripts/search.py
@@ -15,8 +15,16 @@ Persistence (Master + Overrides pattern):
 """
 
 import argparse
+import sys
+import io
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
 from design_system import generate_design_system, persist_design_system
+
+# Force UTF-8 for stdout/stderr to handle emojis on Windows (cp1252 default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 
 def format_output(result):

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {

--- a/src/ui-ux-pro-max/scripts/search.py
+++ b/src/ui-ux-pro-max/scripts/search.py
@@ -15,8 +15,16 @@ Persistence (Master + Overrides pattern):
 """
 
 import argparse
+import sys
+import io
 from core import CSV_CONFIG, AVAILABLE_STACKS, MAX_RESULTS, search, search_stack
 from design_system import generate_design_system, persist_design_system
+
+# Force UTF-8 for stdout/stderr to handle emojis on Windows (cp1252 default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 
 def format_output(result):


### PR DESCRIPTION
## Summary
Force UTF-8 encoding for stdout/stderr in `search.py` to handle emoji characters (⚡, ✓) on Windows systems that default to cp1252 encoding.

## Problem
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u26a1' in position ...: character maps to
```

Windows systems default to cp1252 encoding which cannot handle Unicode emoji characters used in the search results.

## Solution
Add UTF-8 encoding wrapper at script startup:
```python
if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
```

## Test plan
- [x] Published to npm as v2.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)