### PR TITLE
docs: add link to visual style guide at uistyleguide.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Each rule includes:
 
 ### Available Styles (67)
 
+> **See them in action:** Browse all styles with live demos, color palettes, and implementation tips at [uistyleguide.com](https://www.uistyleguide.com)
+
 <details>
 <summary><b>General Styles (49)</b></summary>
 


### PR DESCRIPTION
Hey guys,

I love your skill, and it makes a massive difference in the output of beautiful sites. I'm not a designer, so I find myself going through the list of styles that can be applied, googling them, going back, trying again, etc. It was a bit tedious so I made myself a visual reference guide, and then I thought it could be useful for others as well so I put it online.

You can check it out [here](https://www.uistyleguide.com/). I would love to get a link in your docs so others can benefit from what I've built as well.