### PR TITLE
feat: add Droid (Factory) support

### DIFF
--- a/cli/assets/templates/platforms/droid.json
+++ b/cli/assets/templates/platforms/droid.json
@@ -1,0 +1,21 @@
+{
+  "platform": "droid",
+  "displayName": "Droid (Factory)",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".factory",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "UI/UX Pro Max - Design Intelligence",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'all';
+export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'all';
 
 export type InstallType = 'full' | 'reference';
 
@@ -41,7 +41,7 @@ export interface PlatformConfig {
   skillOrWorkflow: string;
 }
 
-export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'all'];
+export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'all'];
 
 // Legacy folder mapping for backward compatibility with ZIP-based installs
 export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
@@ -59,4 +59,5 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   opencode: ['.opencode', '.shared'],
   continue: ['.continue'],
   codebuddy: ['.codebuddy'],
+  droid: ['.factory'],
 };

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -52,6 +52,9 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.codebuddy'))) {
     detected.push('codebuddy');
   }
+  if (existsSync(join(cwd, '.factory'))) {
+    detected.push('droid');
+  }
 
   // Suggest based on what's detected
   let suggested: AIType | null = null;
@@ -94,6 +97,8 @@ export function getAITypeDescription(aiType: AIType): string {
       return 'Continue (.continue/skills/)';
     case 'codebuddy':
       return 'CodeBuddy (.codebuddy/skills/)';
+    case 'droid':
+      return 'Droid (Factory) (.factory/skills/)';
     case 'all':
       return 'All AI assistants';
   }

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -41,6 +41,7 @@ const AI_TO_PLATFORM: Record<string, string> = {
   trae: 'trae',
   continue: 'continue',
   codebuddy: 'codebuddy',
+  droid: 'droid',
 };
 
 async function exists(path: string): Promise<boolean> {

--- a/src/ui-ux-pro-max/templates/platforms/droid.json
+++ b/src/ui-ux-pro-max/templates/platforms/droid.json
@@ -1,0 +1,21 @@
+{
+  "platform": "droid",
+  "displayName": "Droid (Factory)",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".factory",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "UI/UX Pro Max - Design Intelligence",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}


### PR DESCRIPTION
## Summary
Add support for Factory Droid AI assistant.

## Motivation
Enable UI Pro Max to integrate with Factory Droid, allowing users to generate design systems and UI artifacts directly inside the Factory platform.

## Changes
- Add `droid.json` platform configuration  
- Add `'droid'` to `AIType` and `AI_TYPES`  
- Add `.factory` directory auto-detection  
- Add Droid to `AI_TO_PLATFORM` mapping  

## Usage
After this PR, users can install the skill for Droid via:

```bash
uipro init --ai droid
```

This installs the skill to:

```
.factory/skills/ui-ux-pro-max/
```

## Testing
- Tested locally with Factory Droid  
- Skill loads correctly  
- Design system generation works as expected  

## Related
Closes #122 