### PR TITLE
fix: add Python .gitignore when generating Cursor commands

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -16,6 +16,7 @@ import {
   GitHubRateLimitError,
   GitHubDownloadError,
 } from '../utils/github.js';
+import { addPythonGitignore } from '../utils/gitignore.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // From dist/index.js -> ../assets (one level up to cli/, then assets/)
@@ -190,6 +191,17 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
     console.log();
     logger.success('UI/UX Pro Max installed successfully!');
+
+    // Add Python gitignore if needed
+    try {
+      const gitignoreUpdated = addPythonGitignore(cwd);
+      if (gitignoreUpdated) {
+        logger.info('Added Python gitignore rules to .gitignore');
+      }
+    } catch (error) {
+      // Don't fail installation if gitignore update fails
+      logger.warn('Could not update .gitignore (this is optional)');
+    }
 
     // Next steps
     console.log();

--- a/cli/src/utils/gitignore.ts
+++ b/cli/src/utils/gitignore.ts
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Python gitignore patterns (single source of truth)
+const PYTHON_PATTERNS = [
+  '__pycache__/',
+  '*.py[cod]',
+  '*$py.class',
+  '*.pyo',
+  '*.pyd',
+  '.Python',
+  '*.so',
+  '.venv/',
+  'venv/',
+  'ENV/',
+];
+
+// Generate gitignore content from patterns
+const PYTHON_GITIGNORE = `# Python
+${PYTHON_PATTERNS.join('\n')}
+`;
+
+/**
+ * Add Python gitignore rules to .gitignore file
+ * @param projectRoot Root directory of the project
+ * @returns true if gitignore was updated, false if already exists or no changes needed
+ */
+export function addPythonGitignore(projectRoot: string): boolean {
+  const gitignorePath = join(projectRoot, '.gitignore');
+  
+  // Check if Python section already exists
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, 'utf-8');
+    
+    // Check if any Python pattern already exists (with or without comment)
+    const hasPythonPattern = PYTHON_PATTERNS.some(pattern => content.includes(pattern));
+    const hasPythonComment = content.includes('# Python');
+    
+    if (hasPythonPattern || hasPythonComment) {
+      return false; // Already exists, no changes needed
+    }
+    
+    // Append Python section to existing file
+    const newContent = content.trimEnd() + '\n\n' + PYTHON_GITIGNORE;
+    writeFileSync(gitignorePath, newContent, 'utf-8');
+    return true;
+  } else {
+    // Create new .gitignore file with Python section
+    writeFileSync(gitignorePath, PYTHON_GITIGNORE, 'utf-8');
+    return true;
+  }
+}


### PR DESCRIPTION
## Vấn đề

**Hi các anh**, trong quá trình sử dụng thư viện, em nhận thấy khi thêm commands vào Cursor thì `.gitignore` chưa được tạo. Điều này có thể dẫn đến việc commit nhầm các file cache sinh ra trong quá trình chạy Python.
Vì vậy, em xin bổ sung phần `.gitignore` cho Python để cải thiện trải nghiệm sử dụng và giữ repository gọn gàng hơn.

## Giải pháp

Pull Request này bổ sung template `.gitignore` chuẩn cho Python vào luồng generate commands:

```gitignore
# Python
__pycache__/
*.py[cod]
*$py.class
*.so
.Python