### PR TITLE
feat(gallery): add Style Detail Modal with phone UI controls preview

### DIFF
--- a/gallery/.gitignore
+++ b/gallery/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+out/

--- a/gallery/app/globals.css
+++ b/gallery/app/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100;
+  }
+}
+
+@layer utilities {
+  .scrollbar-thin {
+    scrollbar-width: thin;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    @apply bg-gray-300 dark:bg-gray-700 rounded-full;
+  }
+}

--- a/gallery/app/layout.tsx
+++ b/gallery/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Providers } from "./providers";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Style Gallery — UI/UX Pro Max",
+  description: "Browse and explore 67 UI styles with live previews, color palettes, and implementation details.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen antialiased">
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/gallery/app/page.tsx
+++ b/gallery/app/page.tsx
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+import { parseStylesCSV } from "@/lib/parseStyles";
+import { GalleryGrid } from "@/components/GalleryGrid";
+
+export default function Home() {
+  const csvPath = path.join(process.cwd(), "data", "styles.csv");
+  const csvContent = fs.readFileSync(csvPath, "utf-8");
+  const styles = parseStylesCSV(csvContent);
+
+  return (
+    <main>
+      <GalleryGrid styles={styles} />
+    </main>
+  );
+}

--- a/gallery/app/providers.tsx
+++ b/gallery/app/providers.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider } from "next-themes";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/gallery/components/CodeSnippet.tsx
+++ b/gallery/components/CodeSnippet.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+interface CodeSnippetProps {
+  code: string;
+  label?: string;
+}
+
+export function CodeSnippet({ code, label }: CodeSnippetProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: ignore
+    }
+  }
+
+  return (
+    <div className="relative group">
+      {label && (
+        <span className="text-[10px] font-medium text-gray-400 uppercase tracking-wider">
+          {label}
+        </span>
+      )}
+      <pre className="mt-1 p-3 text-xs bg-gray-50 dark:bg-gray-900 rounded-lg overflow-x-auto scrollbar-thin font-mono text-gray-700 dark:text-gray-300 leading-relaxed">
+        {code}
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-2 right-2 p-1.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 text-gray-500 dark:text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-gray-300 dark:hover:bg-gray-600"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <svg className="w-3.5 h-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/gallery/components/ColorPalette.tsx
+++ b/gallery/components/ColorPalette.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+interface ColorPaletteProps {
+  colors: string[];
+}
+
+export function ColorPalette({ colors }: ColorPaletteProps) {
+  const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+
+  if (colors.length === 0) return null;
+
+  async function copyColor(color: string, idx: number) {
+    try {
+      await navigator.clipboard.writeText(color);
+      setCopiedIdx(idx);
+      setTimeout(() => setCopiedIdx(null), 2000);
+    } catch {
+      // Fallback: ignore
+    }
+  }
+
+  // Show at most 8 colors
+  const displayed = colors.slice(0, 8);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {displayed.map((color, i) => (
+        <div key={`${color}-${i}`} className="group relative">
+          <button
+            onClick={() => copyColor(color, i)}
+            className="w-6 h-6 rounded-full border border-gray-200 dark:border-gray-700 transition-transform hover:scale-125 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            style={{ backgroundColor: color }}
+            title={color}
+          />
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-1.5 py-0.5 text-[10px] font-mono bg-gray-900 text-white rounded opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-10">
+            {copiedIdx === i ? "Copied!" : color}
+          </div>
+        </div>
+      ))}
+      {colors.length > 8 && (
+        <span className="text-xs text-gray-400">+{colors.length - 8}</span>
+      )}
+    </div>
+  );
+}

--- a/gallery/components/DarkModeToggle.tsx
+++ b/gallery/components/DarkModeToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export function DarkModeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="w-9 h-9" />;
+  }
+
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="p-2 rounded-lg bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? (
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      ) : (
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/gallery/components/ExpandableSection.tsx
+++ b/gallery/components/ExpandableSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+interface ExpandableSectionProps {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export function ExpandableSection({
+  title,
+  children,
+  defaultOpen = false,
+}: ExpandableSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-t border-gray-100 dark:border-gray-800">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between py-2 px-1 text-left text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+      >
+        <span>{title}</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${open ? "rotate-90" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      {open && <div className="pb-3 px-1">{children}</div>}
+    </div>
+  );
+}

--- a/gallery/components/FilterBar.tsx
+++ b/gallery/components/FilterBar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Filters } from "@/lib/filterStyles";
+
+interface FilterBarProps {
+  filters: Filters;
+  onChange: (filters: Filters) => void;
+  types: string[];
+  complexities: string[];
+  eras: string[];
+  resultCount: number;
+  totalCount: number;
+}
+
+function FilterGroup({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-xs font-medium text-gray-500 dark:text-gray-400 mr-1">
+        {label}:
+      </span>
+      <button
+        onClick={() => onChange("")}
+        className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+          value === ""
+            ? "bg-blue-500 text-white"
+            : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+        }`}
+      >
+        All
+      </button>
+      {options.map((opt) => (
+        <button
+          key={opt}
+          onClick={() => onChange(value === opt ? "" : opt)}
+          className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+            value === opt
+              ? "bg-blue-500 text-white"
+              : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+          }`}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function FilterBar({
+  filters,
+  onChange,
+  types,
+  complexities,
+  eras,
+  resultCount,
+  totalCount,
+}: FilterBarProps) {
+  const hasFilters =
+    filters.search || filters.type || filters.complexity || filters.era;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-4">
+        <FilterGroup
+          label="Type"
+          options={types}
+          value={filters.type}
+          onChange={(type) => onChange({ ...filters, type })}
+        />
+        <FilterGroup
+          label="Complexity"
+          options={complexities}
+          value={filters.complexity}
+          onChange={(complexity) => onChange({ ...filters, complexity })}
+        />
+      </div>
+      <div className="flex flex-wrap gap-4">
+        <FilterGroup
+          label="Era"
+          options={eras}
+          value={filters.era}
+          onChange={(era) => onChange({ ...filters, era })}
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Showing <span className="font-semibold text-gray-700 dark:text-gray-200">{resultCount}</span> of {totalCount} styles
+        </p>
+        {hasFilters && (
+          <button
+            onClick={() =>
+              onChange({ search: "", type: "", complexity: "", era: "" })
+            }
+            className="text-xs text-blue-500 hover:text-blue-600 transition-colors"
+          >
+            Clear all filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/GalleryGrid.tsx
+++ b/gallery/components/GalleryGrid.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { StyleData } from "@/lib/types";
+import {
+  Filters,
+  DEFAULT_FILTERS,
+  filterStyles,
+  getUniqueValues,
+} from "@/lib/filterStyles";
+import { StyleCard } from "./StyleCard";
+import { StyleDetailModal } from "./StyleDetailModal";
+import { SearchInput } from "./SearchInput";
+import { FilterBar } from "./FilterBar";
+import { DarkModeToggle } from "./DarkModeToggle";
+
+interface GalleryGridProps {
+  styles: StyleData[];
+}
+
+export function GalleryGrid({ styles }: GalleryGridProps) {
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [selectedStyle, setSelectedStyle] = useState<StyleData | null>(null);
+
+  const types = useMemo(() => getUniqueValues(styles, "type"), [styles]);
+  const complexities = useMemo(
+    () => getUniqueValues(styles, "complexity"),
+    [styles]
+  );
+  const eras = useMemo(() => getUniqueValues(styles, "eraOrigin"), [styles]);
+
+  const filtered = useMemo(
+    () => filterStyles(styles, filters),
+    [styles, filters]
+  );
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Style Gallery
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Browse {styles.length} UI styles from Antigravity Kit
+          </p>
+        </div>
+        <DarkModeToggle />
+      </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <SearchInput
+          value={filters.search}
+          onChange={(search) => setFilters((f) => ({ ...f, search }))}
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="mb-6">
+        <FilterBar
+          filters={filters}
+          onChange={setFilters}
+          types={types}
+          complexities={complexities}
+          eras={eras}
+          resultCount={filtered.length}
+          totalCount={styles.length}
+        />
+      </div>
+
+      {/* Grid */}
+      {filtered.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map((style) => (
+            <StyleCard key={style.no} style={style} onSelect={setSelectedStyle} />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-16">
+          <p className="text-gray-500 dark:text-gray-400">
+            No styles match your filters.
+          </p>
+          <button
+            onClick={() => setFilters(DEFAULT_FILTERS)}
+            className="mt-2 text-sm text-blue-500 hover:text-blue-600"
+          >
+            Clear all filters
+          </button>
+        </div>
+      )}
+
+      {/* Style Detail Modal */}
+      {selectedStyle && (
+        <StyleDetailModal
+          style={selectedStyle}
+          onClose={() => setSelectedStyle(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/gallery/components/InteractiveChecklist.tsx
+++ b/gallery/components/InteractiveChecklist.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+interface InteractiveChecklistProps {
+  checklist: string;
+}
+
+function parseItems(raw: string): string[] {
+  return raw
+    .split(/,\s*(?=☐)/)
+    .map((s) => s.replace(/^☐\s*/, "").trim())
+    .filter(Boolean);
+}
+
+export function InteractiveChecklist({ checklist }: InteractiveChecklistProps) {
+  const items = parseItems(checklist);
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+
+  if (items.length === 0) return null;
+
+  function toggle(idx: number) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  return (
+    <div>
+      <div className="text-[10px] text-gray-400 mb-2">
+        {checked.size} of {items.length} completed
+      </div>
+      <div className="space-y-1.5">
+        {items.map((item, i) => (
+          <label
+            key={i}
+            className="flex items-start gap-2 cursor-pointer group"
+          >
+            <input
+              type="checkbox"
+              checked={checked.has(i)}
+              onChange={() => toggle(i)}
+              className="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-blue-500 focus:ring-blue-500"
+            />
+            <span
+              className={`text-xs leading-relaxed transition-colors ${
+                checked.has(i)
+                  ? "line-through text-gray-400 dark:text-gray-600"
+                  : "text-gray-700 dark:text-gray-300"
+              }`}
+            >
+              {item}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/MetadataBadges.tsx
+++ b/gallery/components/MetadataBadges.tsx
@@ -1,0 +1,57 @@
+import { StyleData } from "@/lib/types";
+
+interface MetadataBadgesProps {
+  style: StyleData;
+}
+
+function Badge({
+  label,
+  variant,
+}: {
+  label: string;
+  variant: "green" | "yellow" | "red" | "blue" | "gray";
+}) {
+  const colors = {
+    green: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+    yellow: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+    red: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+    blue: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+    gray: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+  };
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded-full ${colors[variant]}`}>
+      {label}
+    </span>
+  );
+}
+
+function getComplexityVariant(c: string): "green" | "yellow" | "red" {
+  if (c === "Low") return "green";
+  if (c === "Medium") return "yellow";
+  return "red";
+}
+
+function getPerfVariant(p: string): "green" | "yellow" | "red" {
+  if (p.includes("Excellent")) return "green";
+  if (p.includes("Good")) return "yellow";
+  return "red";
+}
+
+function getA11yVariant(a: string): "green" | "yellow" | "red" {
+  if (a.includes("AAA")) return "green";
+  if (a.includes("AA") || a.includes("Good")) return "yellow";
+  return "red";
+}
+
+export function MetadataBadges({ style }: MetadataBadgesProps) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <Badge label={style.complexity} variant={getComplexityVariant(style.complexity)} />
+      <Badge label={style.performance.replace(/[⚡❌⚠]/g, "").trim()} variant={getPerfVariant(style.performance)} />
+      <Badge label={style.accessibility.replace(/[✓⚠✗]/g, "").trim()} variant={getA11yVariant(style.accessibility)} />
+      {style.lightMode.includes("Full") && <Badge label="Light" variant="blue" />}
+      {style.darkMode.includes("Full") && <Badge label="Dark" variant="gray" />}
+    </div>
+  );
+}

--- a/gallery/components/PhoneMockup.tsx
+++ b/gallery/components/PhoneMockup.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from "react";
+
+interface PhoneMockupProps {
+  children: React.ReactNode;
+}
+
+export function PhoneMockup({ children }: PhoneMockupProps) {
+  return (
+    <div className="flex items-center justify-center py-4">
+      {/* iPhone outer frame */}
+      <div
+        className="relative bg-gray-900 rounded-[44px] p-3 shadow-2xl"
+        style={{ width: "300px" }}
+      >
+        {/* Notch / Dynamic Island */}
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 z-20">
+          <div className="bg-gray-900 rounded-b-2xl px-6 pt-0 pb-1.5">
+            <div className="w-20 h-5 bg-black rounded-full" />
+          </div>
+        </div>
+
+        {/* Screen bezel */}
+        <div className="rounded-[32px] overflow-hidden bg-white dark:bg-gray-950 relative">
+          {/* Status bar */}
+          <div className="flex items-center justify-between px-6 pt-3 pb-1 text-[10px] font-semibold relative z-10">
+            <span className="text-gray-900 dark:text-gray-100">9:41</span>
+            <div className="flex items-center gap-1">
+              {/* Signal */}
+              <svg
+                width="14"
+                height="10"
+                viewBox="0 0 14 10"
+                className="text-gray-900 dark:text-gray-100"
+              >
+                <rect x="0" y="7" width="2.5" height="3" rx="0.5" fill="currentColor" />
+                <rect x="3.5" y="5" width="2.5" height="5" rx="0.5" fill="currentColor" />
+                <rect x="7" y="2.5" width="2.5" height="7.5" rx="0.5" fill="currentColor" />
+                <rect x="10.5" y="0" width="2.5" height="10" rx="0.5" fill="currentColor" />
+              </svg>
+              {/* WiFi */}
+              <svg
+                width="12"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-gray-900 dark:text-gray-100"
+              >
+                <path d="M1.42 9a16 16 0 0121.16 0" />
+                <path d="M5 12.55a11 11 0 0114.08 0" />
+                <path d="M8.53 16.11a6 6 0 016.95 0" />
+                <circle cx="12" cy="20" r="1" fill="currentColor" />
+              </svg>
+              {/* Battery */}
+              <div className="flex items-center">
+                <div className="w-5 h-2.5 border border-current rounded-sm relative">
+                  <div className="absolute inset-0.5 bg-current rounded-[1px]" />
+                </div>
+                <div className="w-0.5 h-1 bg-current rounded-r-sm" />
+              </div>
+            </div>
+          </div>
+
+          {/* Content area */}
+          <div
+            className="overflow-y-auto"
+            style={{ height: "540px" }}
+          >
+            {children}
+          </div>
+
+          {/* Home indicator */}
+          <div className="flex justify-center pb-2 pt-1">
+            <div className="w-28 h-1 bg-gray-400 dark:bg-gray-600 rounded-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/SearchInput.tsx
+++ b/gallery/components/SearchInput.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchInput({ value, onChange }: SearchInputProps) {
+  const [local, setLocal] = useState(value);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setLocal(v);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => onChange(v), 300);
+  }
+
+  return (
+    <div className="relative">
+      <svg
+        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      <input
+        type="text"
+        value={local}
+        onChange={handleChange}
+        placeholder="Search styles..."
+        className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder:text-gray-400"
+      />
+      {local && (
+        <button
+          onClick={() => {
+            setLocal("");
+            onChange("");
+          }}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/gallery/components/StyleCard.tsx
+++ b/gallery/components/StyleCard.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { StyleData } from "@/lib/types";
+import { StylePreview } from "./StylePreview";
+import { ColorPalette } from "./ColorPalette";
+import { MetadataBadges } from "./MetadataBadges";
+import { ExpandableSection } from "./ExpandableSection";
+import { CodeSnippet } from "./CodeSnippet";
+import { InteractiveChecklist } from "./InteractiveChecklist";
+
+interface StyleCardProps {
+  style: StyleData;
+  onSelect?: (style: StyleData) => void;
+}
+
+export function StyleCard({ style, onSelect }: StyleCardProps) {
+  return (
+    <div
+      className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden hover:shadow-lg dark:hover:shadow-gray-900/50 transition-shadow cursor-pointer"
+      onClick={() => onSelect?.(style)}
+    >
+      {/* Header */}
+      <div className="px-4 pt-4 pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 leading-tight">
+            {style.styleCategory}
+          </h3>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <span className="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+              {style.type}
+            </span>
+            <span className="text-[10px] text-gray-400">{style.eraOrigin}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Preview */}
+      <div className="px-4">
+        <StylePreview style={style} />
+      </div>
+
+      {/* Color Palette */}
+      <div className="px-4 py-3">
+        <ColorPalette colors={style.extractedColors} />
+      </div>
+
+      {/* Metadata Badges */}
+      <div className="px-4 pb-3">
+        <MetadataBadges style={style} />
+      </div>
+
+      {/* Expandable Sections */}
+      <div className="px-4 pb-2">
+        <ExpandableSection title="CSS Code">
+          <CodeSnippet code={style.cssTechnicalKeywords} label="CSS/Technical" />
+          {style.designSystemVariables && (
+            <div className="mt-2">
+              <CodeSnippet
+                code={style.designSystemVariables}
+                label="Design Variables"
+              />
+            </div>
+          )}
+        </ExpandableSection>
+
+        <ExpandableSection title="AI Prompt">
+          <CodeSnippet code={style.aiPromptKeywords} />
+        </ExpandableSection>
+
+        <ExpandableSection title="Implementation Checklist">
+          <InteractiveChecklist checklist={style.implementationChecklist} />
+        </ExpandableSection>
+
+        <ExpandableSection title="Details">
+          <div className="space-y-2 text-xs">
+            {style.bestFor && (
+              <div>
+                <span className="font-medium text-gray-500 dark:text-gray-400">
+                  Best for:{" "}
+                </span>
+                <span className="text-gray-700 dark:text-gray-300">
+                  {style.bestFor}
+                </span>
+              </div>
+            )}
+            {style.doNotUseFor && (
+              <div>
+                <span className="font-medium text-gray-500 dark:text-gray-400">
+                  Avoid for:{" "}
+                </span>
+                <span className="text-gray-700 dark:text-gray-300">
+                  {style.doNotUseFor}
+                </span>
+              </div>
+            )}
+            {style.frameworkCompatibility && (
+              <div>
+                <span className="font-medium text-gray-500 dark:text-gray-400">
+                  Frameworks:{" "}
+                </span>
+                <span className="text-gray-700 dark:text-gray-300">
+                  {style.frameworkCompatibility}
+                </span>
+              </div>
+            )}
+            {style.keywords && (
+              <div className="flex flex-wrap gap-1 mt-1">
+                {style.keywords
+                  .split(",")
+                  .slice(0, 6)
+                  .map((kw, i) => (
+                    <span
+                      key={i}
+                      className="px-1.5 py-0.5 text-[10px] bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded"
+                    >
+                      {kw.trim()}
+                    </span>
+                  ))}
+              </div>
+            )}
+          </div>
+        </ExpandableSection>
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/StyleDetailModal.tsx
+++ b/gallery/components/StyleDetailModal.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { StyleData } from "@/lib/types";
+import {
+  generatePreviewStyle,
+  generateBackgroundGradient,
+} from "@/lib/cssGenerator";
+import { PhoneMockup } from "./PhoneMockup";
+import { UIControlsShowcase } from "./UIControlsShowcase";
+import { ColorPalette } from "./ColorPalette";
+import { MetadataBadges } from "./MetadataBadges";
+import { ExpandableSection } from "./ExpandableSection";
+import { CodeSnippet } from "./CodeSnippet";
+import { InteractiveChecklist } from "./InteractiveChecklist";
+
+interface StyleDetailModalProps {
+  style: StyleData;
+  onClose: () => void;
+}
+
+export function StyleDetailModal({ style, onClose }: StyleDetailModalProps) {
+  const { theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  // ESC to close
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // Lock body scroll
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  const isDark = mounted ? theme === "dark" : false;
+  const cardStyle = generatePreviewStyle(style, isDark);
+  const bgGradient = generateBackgroundGradient(style.extractedColors, isDark);
+
+  const accentColor =
+    style.extractedColors[0] || (isDark ? "#6366f1" : "#3b82f6");
+  const secondaryColor =
+    style.extractedColors[1] || style.extractedColors[0] || (isDark ? "#8b5cf6" : "#6366f1");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+
+      {/* Modal container */}
+      <div
+        className="relative z-10 bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-[95vw] max-w-5xl max-h-[90vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 shrink-0">
+          <button
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+            Close
+          </button>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {style.styleCategory}
+          </h2>
+          <div className="w-16" /> {/* Spacer for centering */}
+        </div>
+
+        {/* Body — two-column on desktop, single-column on mobile */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="flex flex-col lg:flex-row">
+            {/* Left: Phone mockup */}
+            <div
+              className="lg:w-1/2 flex items-start justify-center p-6 lg:border-r border-gray-200 dark:border-gray-800"
+              style={{ background: bgGradient }}
+            >
+              <PhoneMockup>
+                <UIControlsShowcase
+                  accentColor={accentColor}
+                  secondaryColor={secondaryColor}
+                  borderRadius={cardStyle.borderRadius?.toString() || "8px"}
+                  boxShadow={
+                    cardStyle.boxShadow?.toString() ||
+                    "0 4px 12px rgba(0,0,0,0.1)"
+                  }
+                  backdropFilter={cardStyle.backdropFilter?.toString()}
+                  fontFamily={cardStyle.fontFamily?.toString()}
+                  fontWeight={cardStyle.fontWeight?.toString()}
+                  border={cardStyle.border?.toString()}
+                  textShadow={cardStyle.textShadow?.toString()}
+                  letterSpacing={cardStyle.letterSpacing?.toString()}
+                  isDark={isDark}
+                />
+              </PhoneMockup>
+            </div>
+
+            {/* Right: Details */}
+            <div className="lg:w-1/2 p-6">
+              {/* Color Palette */}
+              <div className="mb-4">
+                <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+                  Color Palette
+                </h4>
+                <ColorPalette colors={style.extractedColors} />
+              </div>
+
+              {/* Metadata */}
+              <div className="mb-4">
+                <MetadataBadges style={style} />
+              </div>
+
+              {/* Expandable sections */}
+              <div>
+                <ExpandableSection title="CSS Code" defaultOpen>
+                  <CodeSnippet
+                    code={style.cssTechnicalKeywords}
+                    label="CSS/Technical"
+                  />
+                  {style.designSystemVariables && (
+                    <div className="mt-2">
+                      <CodeSnippet
+                        code={style.designSystemVariables}
+                        label="Design Variables"
+                      />
+                    </div>
+                  )}
+                </ExpandableSection>
+
+                <ExpandableSection title="AI Prompt">
+                  <CodeSnippet code={style.aiPromptKeywords} />
+                </ExpandableSection>
+
+                <ExpandableSection title="Implementation Checklist">
+                  <InteractiveChecklist
+                    checklist={style.implementationChecklist}
+                  />
+                </ExpandableSection>
+
+                <ExpandableSection title="Details">
+                  <div className="space-y-2 text-xs">
+                    {style.bestFor && (
+                      <div>
+                        <span className="font-medium text-gray-500 dark:text-gray-400">
+                          Best for:{" "}
+                        </span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {style.bestFor}
+                        </span>
+                      </div>
+                    )}
+                    {style.doNotUseFor && (
+                      <div>
+                        <span className="font-medium text-gray-500 dark:text-gray-400">
+                          Avoid for:{" "}
+                        </span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {style.doNotUseFor}
+                        </span>
+                      </div>
+                    )}
+                    {style.frameworkCompatibility && (
+                      <div>
+                        <span className="font-medium text-gray-500 dark:text-gray-400">
+                          Frameworks:{" "}
+                        </span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {style.frameworkCompatibility}
+                        </span>
+                      </div>
+                    )}
+                    {style.keywords && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {style.keywords
+                          .split(",")
+                          .slice(0, 6)
+                          .map((kw, i) => (
+                            <span
+                              key={i}
+                              className="px-1.5 py-0.5 text-[10px] bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded"
+                            >
+                              {kw.trim()}
+                            </span>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                </ExpandableSection>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/StylePreview.tsx
+++ b/gallery/components/StylePreview.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { StyleData } from "@/lib/types";
+import {
+  generatePreviewStyle,
+  generateBackgroundGradient,
+} from "@/lib/cssGenerator";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+interface StylePreviewProps {
+  style: StyleData;
+}
+
+export function StylePreview({ style }: StylePreviewProps) {
+  const { theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const isDark = mounted ? theme === "dark" : false;
+  const cardStyle = generatePreviewStyle(style, isDark);
+  const bgGradient = generateBackgroundGradient(style.extractedColors, isDark);
+  const accentColor = style.extractedColors[0] || (isDark ? "#6366f1" : "#3b82f6");
+
+  return (
+    <div
+      className="relative h-40 rounded-lg overflow-hidden"
+      style={{ background: bgGradient }}
+    >
+      {/* Demo card */}
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div
+          className="w-full max-w-[200px] p-4 bg-white/80 dark:bg-gray-900/80"
+          style={{
+            borderRadius: cardStyle.borderRadius || "8px",
+            boxShadow:
+              cardStyle.boxShadow || "0 4px 12px rgba(0,0,0,0.1)",
+            backdropFilter: cardStyle.backdropFilter,
+            WebkitBackdropFilter: cardStyle.WebkitBackdropFilter,
+            border: cardStyle.border || "1px solid rgba(128,128,128,0.1)",
+            fontFamily: cardStyle.fontFamily,
+            fontWeight: cardStyle.fontWeight,
+            filter: cardStyle.filter,
+            textShadow: cardStyle.textShadow,
+            letterSpacing: cardStyle.letterSpacing,
+            transition: cardStyle.transition || "all 0.2s ease",
+          }}
+        >
+          <div
+            className="h-2 rounded-full mb-2 w-3/4"
+            style={{ background: accentColor }}
+          />
+          <div className="h-1.5 rounded-full bg-gray-300 dark:bg-gray-600 mb-1.5 w-full" />
+          <div className="h-1.5 rounded-full bg-gray-300 dark:bg-gray-600 mb-1.5 w-5/6" />
+          <div className="h-1.5 rounded-full bg-gray-300 dark:bg-gray-600 w-2/3" />
+          <div
+            className="mt-3 h-6 rounded flex items-center justify-center"
+            style={{
+              background: accentColor,
+              borderRadius: cardStyle.borderRadius
+                ? `calc(${cardStyle.borderRadius} / 2)`
+                : "4px",
+            }}
+          >
+            <span className="text-[10px] font-medium text-white">
+              Button
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Style name overlay */}
+      <div className="absolute bottom-0 left-0 right-0 px-3 py-1.5 bg-gradient-to-t from-black/40 to-transparent">
+        <span className="text-[10px] font-medium text-white/80">
+          Preview
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/gallery/components/UIControlsShowcase.tsx
+++ b/gallery/components/UIControlsShowcase.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import React, { useState } from "react";
+
+interface UIControlsShowcaseProps {
+  accentColor: string;
+  secondaryColor: string;
+  borderRadius: string;
+  boxShadow: string;
+  backdropFilter?: string;
+  fontFamily?: string;
+  fontWeight?: string;
+  border?: string;
+  textShadow?: string;
+  letterSpacing?: string;
+  isDark: boolean;
+}
+
+export function UIControlsShowcase({
+  accentColor,
+  secondaryColor,
+  borderRadius,
+  boxShadow,
+  backdropFilter,
+  fontFamily,
+  fontWeight,
+  border,
+  textShadow,
+  letterSpacing,
+  isDark,
+}: UIControlsShowcaseProps) {
+  const [toggle1, setToggle1] = useState(true);
+  const [toggle2, setToggle2] = useState(false);
+  const [check1, setCheck1] = useState(true);
+  const [check2, setCheck2] = useState(false);
+  const [radio, setRadio] = useState<"a" | "b">("a");
+  const [slider, setSlider] = useState(65);
+
+  const bg = isDark ? "#1a1a2e" : "#ffffff";
+  const textPrimary = isDark ? "#f1f5f9" : "#1e293b";
+  const textSecondary = isDark ? "#94a3b8" : "#64748b";
+  const surfaceBg = isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.03)";
+  const borderColor = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.08)";
+  const halfRadius = `calc(${borderRadius} / 2)`;
+
+  const baseFont: React.CSSProperties = {
+    fontFamily,
+    fontWeight,
+    textShadow,
+    letterSpacing,
+  };
+
+  return (
+    <div
+      style={{
+        background: bg,
+        color: textPrimary,
+        padding: "16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px",
+        fontSize: "13px",
+        lineHeight: 1.4,
+        minHeight: "100%",
+        ...baseFont,
+      }}
+    >
+      {/* 1. Buttons */}
+      <Section label="Buttons" textSecondary={textSecondary}>
+        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+          <button
+            style={{
+              background: accentColor,
+              color: "#fff",
+              border: "none",
+              borderRadius: halfRadius,
+              padding: "8px 16px",
+              fontSize: "13px",
+              fontWeight: 600,
+              boxShadow,
+              cursor: "pointer",
+              ...baseFont,
+            }}
+          >
+            Primary
+          </button>
+          <button
+            style={{
+              background: secondaryColor,
+              color: "#fff",
+              border: "none",
+              borderRadius: halfRadius,
+              padding: "8px 16px",
+              fontSize: "13px",
+              fontWeight: 600,
+              cursor: "pointer",
+              ...baseFont,
+            }}
+          >
+            Secondary
+          </button>
+          <button
+            style={{
+              background: "transparent",
+              color: accentColor,
+              border: `1.5px solid ${accentColor}`,
+              borderRadius: halfRadius,
+              padding: "8px 16px",
+              fontSize: "13px",
+              fontWeight: 600,
+              cursor: "pointer",
+              ...baseFont,
+            }}
+          >
+            Outline
+          </button>
+        </div>
+      </Section>
+
+      {/* 2. Text Input */}
+      <Section label="Text Input" textSecondary={textSecondary}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          <input
+            type="text"
+            placeholder="Placeholder text..."
+            style={{
+              background: surfaceBg,
+              color: textPrimary,
+              border: border || `1px solid ${borderColor}`,
+              borderRadius: halfRadius,
+              padding: "8px 12px",
+              fontSize: "13px",
+              outline: "none",
+              width: "100%",
+              boxSizing: "border-box",
+              ...baseFont,
+            }}
+          />
+          <input
+            type="text"
+            value="Filled input"
+            readOnly
+            style={{
+              background: surfaceBg,
+              color: textPrimary,
+              border: border || `1px solid ${accentColor}44`,
+              borderRadius: halfRadius,
+              padding: "8px 12px",
+              fontSize: "13px",
+              outline: "none",
+              width: "100%",
+              boxSizing: "border-box",
+              ...baseFont,
+            }}
+          />
+        </div>
+      </Section>
+
+      {/* 3. Toggle Switch */}
+      <Section label="Toggle" textSecondary={textSecondary}>
+        <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+          <ToggleSwitch
+            on={toggle1}
+            onToggle={() => setToggle1(!toggle1)}
+            accentColor={accentColor}
+            borderRadius={borderRadius}
+          />
+          <ToggleSwitch
+            on={toggle2}
+            onToggle={() => setToggle2(!toggle2)}
+            accentColor={accentColor}
+            borderRadius={borderRadius}
+          />
+        </div>
+      </Section>
+
+      {/* 4. Checkbox */}
+      <Section label="Checkbox" textSecondary={textSecondary}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          <CheckboxItem
+            checked={check1}
+            onToggle={() => setCheck1(!check1)}
+            label="Checked option"
+            accentColor={accentColor}
+            halfRadius={halfRadius}
+            textPrimary={textPrimary}
+            baseFont={baseFont}
+          />
+          <CheckboxItem
+            checked={check2}
+            onToggle={() => setCheck2(!check2)}
+            label="Unchecked option"
+            accentColor={accentColor}
+            halfRadius={halfRadius}
+            textPrimary={textPrimary}
+            baseFont={baseFont}
+          />
+        </div>
+      </Section>
+
+      {/* 5. Radio Button */}
+      <Section label="Radio" textSecondary={textSecondary}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          <RadioItem
+            selected={radio === "a"}
+            onSelect={() => setRadio("a")}
+            label="Option A"
+            accentColor={accentColor}
+            textPrimary={textPrimary}
+            baseFont={baseFont}
+          />
+          <RadioItem
+            selected={radio === "b"}
+            onSelect={() => setRadio("b")}
+            label="Option B"
+            accentColor={accentColor}
+            textPrimary={textPrimary}
+            baseFont={baseFont}
+          />
+        </div>
+      </Section>
+
+      {/* 6. Card */}
+      <Section label="Card" textSecondary={textSecondary}>
+        <div
+          style={{
+            background: surfaceBg,
+            borderRadius,
+            boxShadow,
+            border: border || `1px solid ${borderColor}`,
+            overflow: "hidden",
+            backdropFilter,
+            WebkitBackdropFilter: backdropFilter,
+          }}
+        >
+          <div
+            style={{
+              height: "64px",
+              background: `linear-gradient(135deg, ${accentColor}44, ${secondaryColor}44)`,
+            }}
+          />
+          <div style={{ padding: "10px 12px" }}>
+            <div
+              style={{
+                fontSize: "13px",
+                fontWeight: 600,
+                marginBottom: "4px",
+                ...baseFont,
+              }}
+            >
+              Card Title
+            </div>
+            <div
+              style={{
+                fontSize: "11px",
+                color: textSecondary,
+                ...baseFont,
+              }}
+            >
+              A short description of this card with some preview text.
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* 7. Badge / Tag */}
+      <Section label="Badges" textSecondary={textSecondary}>
+        <div style={{ display: "flex", gap: "6px", flexWrap: "wrap" }}>
+          {["Design", "UI/UX", "Style", "Modern"].map((tag) => (
+            <span
+              key={tag}
+              style={{
+                background: `${accentColor}22`,
+                color: accentColor,
+                padding: "3px 10px",
+                borderRadius: "999px",
+                fontSize: "11px",
+                fontWeight: 500,
+                ...baseFont,
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </Section>
+
+      {/* 8. Slider */}
+      <Section label="Slider" textSecondary={textSecondary}>
+        <div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              marginBottom: "6px",
+              fontSize: "11px",
+              color: textSecondary,
+            }}
+          >
+            <span>0</span>
+            <span style={{ color: accentColor, fontWeight: 600 }}>
+              {slider}
+            </span>
+            <span>100</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={slider}
+            onChange={(e) => setSlider(Number(e.target.value))}
+            style={{
+              width: "100%",
+              accentColor,
+              cursor: "pointer",
+            }}
+          />
+        </div>
+      </Section>
+
+      {/* 9. Navigation Bar */}
+      <Section label="Nav Bar" textSecondary={textSecondary}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-around",
+            alignItems: "center",
+            background: surfaceBg,
+            borderRadius: halfRadius,
+            padding: "8px 0",
+            border: border || `1px solid ${borderColor}`,
+          }}
+        >
+          <NavIcon
+            label="Home"
+            active
+            accentColor={accentColor}
+            textSecondary={textSecondary}
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0h4"
+          />
+          <NavIcon
+            label="Search"
+            accentColor={accentColor}
+            textSecondary={textSecondary}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+          <NavIcon
+            label="Heart"
+            accentColor={accentColor}
+            textSecondary={textSecondary}
+            d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+          />
+          <NavIcon
+            label="Profile"
+            accentColor={accentColor}
+            textSecondary={textSecondary}
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+/* --- Sub-components --- */
+
+function Section({
+  label,
+  textSecondary,
+  children,
+}: {
+  label: string;
+  textSecondary: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: "10px",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          color: textSecondary,
+          marginBottom: "6px",
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ToggleSwitch({
+  on,
+  onToggle,
+  accentColor,
+  borderRadius,
+}: {
+  on: boolean;
+  onToggle: () => void;
+  accentColor: string;
+  borderRadius: string;
+}) {
+  const trackRadius =
+    borderRadius && parseInt(borderRadius) > 20 ? "999px" : "12px";
+  return (
+    <button
+      onClick={onToggle}
+      style={{
+        width: "44px",
+        height: "24px",
+        borderRadius: trackRadius,
+        background: on ? accentColor : "rgba(128,128,128,0.3)",
+        border: "none",
+        position: "relative",
+        cursor: "pointer",
+        transition: "background 0.2s",
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          width: "18px",
+          height: "18px",
+          borderRadius: trackRadius,
+          background: "#fff",
+          position: "absolute",
+          top: "3px",
+          left: on ? "23px" : "3px",
+          transition: "left 0.2s",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+        }}
+      />
+    </button>
+  );
+}
+
+function CheckboxItem({
+  checked,
+  onToggle,
+  label,
+  accentColor,
+  halfRadius,
+  textPrimary,
+  baseFont,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+  accentColor: string;
+  halfRadius: string;
+  textPrimary: string;
+  baseFont: React.CSSProperties;
+}) {
+  return (
+    <label
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        cursor: "pointer",
+        fontSize: "13px",
+        color: textPrimary,
+        ...baseFont,
+      }}
+    >
+      <div
+        onClick={(e) => {
+          e.preventDefault();
+          onToggle();
+        }}
+        style={{
+          width: "18px",
+          height: "18px",
+          borderRadius: `min(${halfRadius}, 4px)`,
+          border: checked
+            ? `2px solid ${accentColor}`
+            : "2px solid rgba(128,128,128,0.4)",
+          background: checked ? accentColor : "transparent",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          transition: "all 0.15s",
+          cursor: "pointer",
+        }}
+      >
+        {checked && (
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#fff"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 13l4 4L19 7" />
+          </svg>
+        )}
+      </div>
+      {label}
+    </label>
+  );
+}
+
+function RadioItem({
+  selected,
+  onSelect,
+  label,
+  accentColor,
+  textPrimary,
+  baseFont,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  label: string;
+  accentColor: string;
+  textPrimary: string;
+  baseFont: React.CSSProperties;
+}) {
+  return (
+    <label
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        cursor: "pointer",
+        fontSize: "13px",
+        color: textPrimary,
+        ...baseFont,
+      }}
+      onClick={(e) => {
+        e.preventDefault();
+        onSelect();
+      }}
+    >
+      <div
+        style={{
+          width: "18px",
+          height: "18px",
+          borderRadius: "50%",
+          border: selected
+            ? `2px solid ${accentColor}`
+            : "2px solid rgba(128,128,128,0.4)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          transition: "all 0.15s",
+        }}
+      >
+        {selected && (
+          <div
+            style={{
+              width: "10px",
+              height: "10px",
+              borderRadius: "50%",
+              background: accentColor,
+            }}
+          />
+        )}
+      </div>
+      {label}
+    </label>
+  );
+}
+
+function NavIcon({
+  label,
+  active,
+  accentColor,
+  textSecondary,
+  d,
+}: {
+  label: string;
+  active?: boolean;
+  accentColor: string;
+  textSecondary: string;
+  d: string;
+}) {
+  const color = active ? accentColor : textSecondary;
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "2px",
+      }}
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d={d} />
+      </svg>
+      <span style={{ fontSize: "9px", color }}>{label}</span>
+    </div>
+  );
+}

--- a/gallery/data/styles.csv
+++ b/gallery/data/styles.csv
@@ -1,0 +1,1 @@
+../../src/ui-ux-pro-max/data/styles.csv

--- a/gallery/lib/colorExtractor.ts
+++ b/gallery/lib/colorExtractor.ts
@@ -1,0 +1,34 @@
+const HEX_RE = /#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{3})\b/g;
+const RGBA_RE = /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*[\d.]+\s*)?\)/g;
+
+function normalizeHex(hex: string): string {
+  hex = hex.toUpperCase();
+  if (hex.length === 4) {
+    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  }
+  return hex;
+}
+
+export function extractColors(text: string): string[] {
+  const colors: string[] = [];
+  const seen = new Set<string>();
+
+  const hexMatches = text.match(HEX_RE) || [];
+  for (const h of hexMatches) {
+    const normalized = normalizeHex(h);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      colors.push(normalized);
+    }
+  }
+
+  const rgbaMatches = text.match(RGBA_RE) || [];
+  for (const r of rgbaMatches) {
+    if (!seen.has(r)) {
+      seen.add(r);
+      colors.push(r);
+    }
+  }
+
+  return colors;
+}

--- a/gallery/lib/cssGenerator.ts
+++ b/gallery/lib/cssGenerator.ts
@@ -1,0 +1,133 @@
+import React from "react";
+
+const CSS_PROPERTY_MAP: Record<string, string> = {
+  "border-radius": "borderRadius",
+  "box-shadow": "boxShadow",
+  "backdrop-filter": "backdropFilter",
+  "-webkit-backdrop-filter": "WebkitBackdropFilter",
+  background: "background",
+  "background-color": "backgroundColor",
+  color: "color",
+  "font-family": "fontFamily",
+  "font-weight": "fontWeight",
+  "font-size": "fontSize",
+  border: "border",
+  transition: "transition",
+  transform: "transform",
+  filter: "filter",
+  opacity: "opacity",
+  "mix-blend-mode": "mixBlendMode",
+  "text-shadow": "textShadow",
+  "letter-spacing": "letterSpacing",
+  gap: "gap",
+  padding: "padding",
+  "max-width": "maxWidth",
+  display: "display",
+  "text-transform": "textTransform",
+};
+
+export function parseCssKeywords(
+  cssTechnical: string
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!cssTechnical) return result;
+
+  // Match patterns like "property: value"
+  const re = /([\w-]+)\s*:\s*([^,;]+?)(?=\s*[,;]|\s+[\w-]+\s*:|$)/g;
+  let match;
+
+  while ((match = re.exec(cssTechnical)) !== null) {
+    const prop = match[1].trim().toLowerCase();
+    const val = match[2].trim();
+    if (CSS_PROPERTY_MAP[prop]) {
+      result[CSS_PROPERTY_MAP[prop]] = val;
+    }
+  }
+
+  return result;
+}
+
+export function generatePreviewStyle(
+  style: { extractedColors: string[]; cssProperties: Record<string, string> },
+  isDark: boolean
+): React.CSSProperties {
+  const colors = style.extractedColors;
+  const props = style.cssProperties;
+
+  const baseStyle: React.CSSProperties = {};
+
+  // Apply border-radius
+  if (props.borderRadius) {
+    baseStyle.borderRadius = props.borderRadius;
+  }
+
+  // Apply box-shadow
+  if (props.boxShadow) {
+    baseStyle.boxShadow = props.boxShadow;
+  }
+
+  // Apply backdrop-filter
+  if (props.backdropFilter) {
+    baseStyle.backdropFilter = props.backdropFilter;
+    baseStyle.WebkitBackdropFilter = props.backdropFilter;
+  }
+
+  // Apply font-family
+  if (props.fontFamily) {
+    baseStyle.fontFamily = props.fontFamily;
+  }
+
+  // Apply font-weight
+  if (props.fontWeight) {
+    baseStyle.fontWeight = props.fontWeight;
+  }
+
+  // Apply border
+  if (props.border) {
+    baseStyle.border = props.border;
+  }
+
+  // Apply transition
+  if (props.transition) {
+    baseStyle.transition = props.transition;
+  }
+
+  // Apply filter
+  if (props.filter) {
+    baseStyle.filter = props.filter;
+  }
+
+  // Apply text-shadow
+  if (props.textShadow) {
+    baseStyle.textShadow = props.textShadow;
+  }
+
+  // Apply letter-spacing
+  if (props.letterSpacing) {
+    baseStyle.letterSpacing = props.letterSpacing;
+  }
+
+  return baseStyle;
+}
+
+export function generateBackgroundGradient(
+  colors: string[],
+  isDark: boolean
+): string {
+  if (colors.length === 0) {
+    return isDark
+      ? "linear-gradient(135deg, #1a1a2e, #16213e)"
+      : "linear-gradient(135deg, #f5f7fa, #c3cfe2)";
+  }
+  if (colors.length === 1) {
+    const c = colors[0];
+    return isDark
+      ? `linear-gradient(135deg, ${c}33, ${c}11)`
+      : `linear-gradient(135deg, ${c}22, ${c}11)`;
+  }
+  const c1 = colors[0];
+  const c2 = colors[1];
+  return isDark
+    ? `linear-gradient(135deg, ${c1}44, ${c2}22)`
+    : `linear-gradient(135deg, ${c1}22, ${c2}11)`;
+}

--- a/gallery/lib/filterStyles.ts
+++ b/gallery/lib/filterStyles.ts
@@ -1,0 +1,55 @@
+import { StyleData } from "./types";
+
+export interface Filters {
+  search: string;
+  type: string;
+  complexity: string;
+  era: string;
+}
+
+export const DEFAULT_FILTERS: Filters = {
+  search: "",
+  type: "",
+  complexity: "",
+  era: "",
+};
+
+export function getUniqueValues(
+  styles: StyleData[],
+  key: keyof StyleData
+): string[] {
+  const set = new Set<string>();
+  for (const s of styles) {
+    const val = String(s[key]).trim();
+    if (val) set.add(val);
+  }
+  return Array.from(set).sort();
+}
+
+export function filterStyles(
+  styles: StyleData[],
+  filters: Filters
+): StyleData[] {
+  return styles.filter((s) => {
+    if (filters.type && s.type !== filters.type) return false;
+    if (filters.complexity && s.complexity !== filters.complexity) return false;
+    if (filters.era && s.eraOrigin !== filters.era) return false;
+
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      const searchable = [
+        s.styleCategory,
+        s.keywords,
+        s.bestFor,
+        s.eraOrigin,
+        s.type,
+        s.complexity,
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!searchable.includes(q)) return false;
+    }
+
+    return true;
+  });
+}

--- a/gallery/lib/parseStyles.ts
+++ b/gallery/lib/parseStyles.ts
@@ -1,0 +1,77 @@
+import { StyleData } from "./types";
+import { extractColors } from "./colorExtractor";
+import { parseCssKeywords } from "./cssGenerator";
+
+function parseCSVLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ",") {
+        fields.push(current.trim());
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+  }
+  fields.push(current.trim());
+  return fields;
+}
+
+export function parseStylesCSV(csvContent: string): StyleData[] {
+  const lines = csvContent.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  // Skip header
+  const dataLines = lines.slice(1);
+  return dataLines.map((line) => {
+    const f = parseCSVLine(line);
+    const primaryColors = f[4] || "";
+    const secondaryColors = f[5] || "";
+    const cssTechnicalKeywords = f[19] || "";
+
+    return {
+      no: parseInt(f[0]) || 0,
+      styleCategory: f[1] || "",
+      type: f[2] || "",
+      keywords: f[3] || "",
+      primaryColors,
+      secondaryColors,
+      effectsAnimation: f[6] || "",
+      bestFor: f[7] || "",
+      doNotUseFor: f[8] || "",
+      lightMode: f[9] || "",
+      darkMode: f[10] || "",
+      performance: f[11] || "",
+      accessibility: f[12] || "",
+      mobileFriendly: f[13] || "",
+      conversionFocused: f[14] || "",
+      frameworkCompatibility: f[15] || "",
+      eraOrigin: f[16] || "",
+      complexity: f[17] || "",
+      aiPromptKeywords: f[18] || "",
+      cssTechnicalKeywords,
+      implementationChecklist: f[20] || "",
+      designSystemVariables: f[21] || "",
+      extractedColors: extractColors(`${primaryColors} ${secondaryColors}`),
+      cssProperties: parseCssKeywords(cssTechnicalKeywords),
+    };
+  });
+}

--- a/gallery/lib/types.ts
+++ b/gallery/lib/types.ts
@@ -1,0 +1,27 @@
+export interface StyleData {
+  no: number;
+  styleCategory: string;
+  type: string;
+  keywords: string;
+  primaryColors: string;
+  secondaryColors: string;
+  effectsAnimation: string;
+  bestFor: string;
+  doNotUseFor: string;
+  lightMode: string;
+  darkMode: string;
+  performance: string;
+  accessibility: string;
+  mobileFriendly: string;
+  conversionFocused: string;
+  frameworkCompatibility: string;
+  eraOrigin: string;
+  complexity: string;
+  aiPromptKeywords: string;
+  cssTechnicalKeywords: string;
+  implementationChecklist: string;
+  designSystemVariables: string;
+  // Computed fields
+  extractedColors: string[];
+  cssProperties: Record<string, string>;
+}

--- a/gallery/next-env.d.ts
+++ b/gallery/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/gallery/next.config.js
+++ b/gallery/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/gallery/package-lock.json
+++ b/gallery/package-lock.json
@@ -1,0 +1,1628 @@
+{
+  "name": "style-gallery",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "style-gallery",
+      "version": "1.0.0",
+      "dependencies": {
+        "next": "^14.2.0",
+        "next-themes": "^0.4.4",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "autoprefixer": "^10.4.0",
+        "postcss": "^8.4.0",
+        "tailwindcss": "^3.4.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmmirror.com/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmmirror.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmmirror.com/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmmirror.com/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.33",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmmirror.com/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmmirror.com/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.24",
+      "resolved": "https://registry.npmmirror.com/autoprefixer/-/autoprefixer-10.4.24.tgz",
+      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001766",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmmirror.com/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmmirror.com/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmmirror.com/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmmirror.com/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmmirror.com/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmmirror.com/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmmirror.com/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmmirror.com/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmmirror.com/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmmirror.com/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmmirror.com/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmmirror.com/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmmirror.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "style-gallery",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "next-themes": "^0.4.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/gallery/postcss.config.js
+++ b/gallery/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/gallery/tailwind.config.ts
+++ b/gallery/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+  ],
+  darkMode: "class",
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/gallery/tsconfig.json
+++ b/gallery/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Click any StyleCard to open a full-screen detail modal with a two-column layout
- Left column: iPhone mockup frame rendering 9 interactive UI controls (buttons, text input, toggle switch, checkbox, radio, card, badges, slider, nav bar) styled with the selected style's CSS properties
- Right column: color palette, metadata badges, expandable CSS code / AI prompt / checklist / details sections
- Responsive (desktop two-column, mobile single-column), ESC / backdrop click to close, dark mode support

## Test plan
- [ ] Click a StyleCard → modal opens with phone mockup + details panel
- [ ] Verify all 9 controls inside the phone frame use the style's colors, border-radius, shadows, fonts
- [ ] Toggle switches and slider are interactive (click/drag)
- [ ] ESC key closes the modal
- [ ] Clicking the backdrop closes the modal
- [ ] Dark mode toggle works correctly inside the modal
- [ ] Mobile viewport shows single-column layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)