### PR TITLE
fix: use portable skill directory path in SKILL.md

### DIFF
--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -89,6 +89,23 @@ Reference these guidelines when:
 
 Search specific domains using the CLI tool below.
 
+## Skill Location
+
+This skill may be installed in different locations depending on the AI tool:
+- **Claude Code (project)**: `.claude/skills/ui-ux-pro-max/`
+- **Claude Code (user)**: `~/.claude/skills/ui-ux-pro-max/`
+- **OpenCode**: `~/.agents/skills/ui-ux-pro-max/`
+- **Other tools**: `skills/ui-ux-pro-max/` or `.shared/ui-ux-pro-max/`
+
+Before running any script, locate the directory containing this SKILL.md file. All commands below use `<skill_dir>` to refer to that directory. The Python scripts use `__file__` for internal data resolution, so they work from any location — just provide the correct path to `search.py`.
+
+```bash
+# Detect skill directory (use the first match):
+SKILL_DIR="$(find ~/.claude/skills ~/.agents/skills .claude/skills skills .shared -maxdepth 1 -name 'ui-ux-pro-max' -type d 2>/dev/null | head -1)"
+```
+
+---
+
 ---
 
 ## Prerequisites
@@ -135,7 +152,7 @@ Extract key information from user request:
 **Always start with `--design-system`** to get comprehensive recommendations with reasoning:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
+python3 <skill_dir>/scripts/search.py "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
 ```
 
 This command:
@@ -146,7 +163,7 @@ This command:
 
 **Example:**
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
 ### Step 2b: Persist Design System (Master + Overrides Pattern)
@@ -154,7 +171,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --d
 To save the design system for **hierarchical retrieval across sessions**, add `--persist`:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name"
 ```
 
 This creates:
@@ -163,7 +180,7 @@ This creates:
 
 **With page-specific override:**
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
 ```
 
 This also creates:
@@ -188,7 +205,7 @@ Now, generate the code...
 After getting the design system, use domain searches to get additional details:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n <max_results>]
+python3 <skill_dir>/scripts/search.py "<keyword>" --domain <domain> [-n <max_results>]
 ```
 
 **When to use detailed searches:**
@@ -206,7 +223,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 Get implementation-specific best practices. If user doesn't specify a stack, **default to `html-tailwind`**.
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
@@ -260,7 +277,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 ### Step 2: Generate Design System (REQUIRED)
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
 ```
 
 **Output:** Complete design system with pattern, style, colors, typography, effects, and anti-patterns.
@@ -269,16 +286,16 @@ python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service eleg
 
 ```bash
 # Get UX guidelines for animation and accessibility
-python3 skills/ui-ux-pro-max/scripts/search.py "animation accessibility" --domain ux
+python3 <skill_dir>/scripts/search.py "animation accessibility" --domain ux
 
 # Get alternative typography options if needed
-python3 skills/ui-ux-pro-max/scripts/search.py "elegant luxury serif" --domain typography
+python3 <skill_dir>/scripts/search.py "elegant luxury serif" --domain typography
 ```
 
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "layout responsive form" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "layout responsive form" --stack html-tailwind
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -291,10 +308,10 @@ The `--design-system` flag supports two output formats:
 
 ```bash
 # ASCII box (default) - best for terminal display
-python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system
 
 # Markdown - best for documentation
-python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system -f markdown
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system -f markdown
 ```
 
 ---

--- a/cli/assets/templates/base/skill-content.md
+++ b/cli/assets/templates/base/skill-content.md
@@ -2,6 +2,23 @@
 
 {{DESCRIPTION}}
 {{QUICK_REFERENCE}}
+## Skill Location
+
+This skill may be installed in different locations depending on the AI tool:
+- **Claude Code (project)**: `.claude/skills/ui-ux-pro-max/`
+- **Claude Code (user)**: `~/.claude/skills/ui-ux-pro-max/`
+- **OpenCode**: `~/.agents/skills/ui-ux-pro-max/`
+- **Other tools**: `skills/ui-ux-pro-max/` or `.shared/ui-ux-pro-max/`
+
+Before running any script, locate the directory containing this SKILL.md file. All commands below use `<skill_dir>` to refer to that directory. The Python scripts use `__file__` for internal data resolution, so they work from any location — just provide the correct path to `search.py`.
+
+```bash
+# Detect skill directory (use the first match):
+SKILL_DIR="$(find ~/.claude/skills ~/.agents/skills .claude/skills skills .shared -maxdepth 1 -name 'ui-ux-pro-max' -type d 2>/dev/null | head -1)"
+```
+
+---
+
 ## Prerequisites
 
 Check if Python is installed:
@@ -46,7 +63,7 @@ Extract key information from user request:
 **Always start with `--design-system`** to get comprehensive recommendations with reasoning:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
+python3 <skill_dir>/scripts/search.py "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
 ```
 
 This command:
@@ -57,7 +74,7 @@ This command:
 
 **Example:**
 ```bash
-python3 {{SCRIPT_PATH}} "beauty spa wellness service" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
 ### Step 2b: Persist Design System (Master + Overrides Pattern)
@@ -65,7 +82,7 @@ python3 {{SCRIPT_PATH}} "beauty spa wellness service" --design-system -p "Sereni
 To save the design system for hierarchical retrieval across sessions, add `--persist`:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name"
 ```
 
 This creates:
@@ -74,7 +91,7 @@ This creates:
 
 **With page-specific override:**
 ```bash
-python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
 ```
 
 This also creates:
@@ -90,7 +107,7 @@ This also creates:
 After getting the design system, use domain searches to get additional details:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<keyword>" --domain <domain> [-n <max_results>]
+python3 <skill_dir>/scripts/search.py "<keyword>" --domain <domain> [-n <max_results>]
 ```
 
 **When to use detailed searches:**
@@ -108,7 +125,7 @@ python3 {{SCRIPT_PATH}} "<keyword>" --domain <domain> [-n <max_results>]
 Get implementation-specific best practices. If user doesn't specify a stack, **default to `html-tailwind`**.
 
 ```bash
-python3 {{SCRIPT_PATH}} "<keyword>" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
@@ -162,7 +179,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 ### Step 2: Generate Design System (REQUIRED)
 
 ```bash
-python3 {{SCRIPT_PATH}} "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
 ```
 
 **Output:** Complete design system with pattern, style, colors, typography, effects, and anti-patterns.
@@ -171,16 +188,16 @@ python3 {{SCRIPT_PATH}} "beauty spa wellness service elegant" --design-system -p
 
 ```bash
 # Get UX guidelines for animation and accessibility
-python3 {{SCRIPT_PATH}} "animation accessibility" --domain ux
+python3 <skill_dir>/scripts/search.py "animation accessibility" --domain ux
 
 # Get alternative typography options if needed
-python3 {{SCRIPT_PATH}} "elegant luxury serif" --domain typography
+python3 <skill_dir>/scripts/search.py "elegant luxury serif" --domain typography
 ```
 
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 {{SCRIPT_PATH}} "layout responsive form" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "layout responsive form" --stack html-tailwind
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -193,10 +210,10 @@ The `--design-system` flag supports two output formats:
 
 ```bash
 # ASCII box (default) - best for terminal display
-python3 {{SCRIPT_PATH}} "fintech crypto" --design-system
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system
 
 # Markdown - best for documentation
-python3 {{SCRIPT_PATH}} "fintech crypto" --design-system -f markdown
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system -f markdown
 ```
 
 ---

--- a/src/ui-ux-pro-max/templates/base/skill-content.md
+++ b/src/ui-ux-pro-max/templates/base/skill-content.md
@@ -2,6 +2,23 @@
 
 {{DESCRIPTION}}
 {{QUICK_REFERENCE}}
+## Skill Location
+
+This skill may be installed in different locations depending on the AI tool:
+- **Claude Code (project)**: `.claude/skills/ui-ux-pro-max/`
+- **Claude Code (user)**: `~/.claude/skills/ui-ux-pro-max/`
+- **OpenCode**: `~/.agents/skills/ui-ux-pro-max/`
+- **Other tools**: `skills/ui-ux-pro-max/` or `.shared/ui-ux-pro-max/`
+
+Before running any script, locate the directory containing this SKILL.md file. All commands below use `<skill_dir>` to refer to that directory. The Python scripts use `__file__` for internal data resolution, so they work from any location — just provide the correct path to `search.py`.
+
+```bash
+# Detect skill directory (use the first match):
+SKILL_DIR="$(find ~/.claude/skills ~/.agents/skills .claude/skills skills .shared -maxdepth 1 -name 'ui-ux-pro-max' -type d 2>/dev/null | head -1)"
+```
+
+---
+
 ## Prerequisites
 
 Check if Python is installed:
@@ -46,7 +63,7 @@ Extract key information from user request:
 **Always start with `--design-system`** to get comprehensive recommendations with reasoning:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
+python3 <skill_dir>/scripts/search.py "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
 ```
 
 This command:
@@ -57,7 +74,7 @@ This command:
 
 **Example:**
 ```bash
-python3 {{SCRIPT_PATH}} "beauty spa wellness service" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
 ### Step 2b: Persist Design System (Master + Overrides Pattern)
@@ -65,7 +82,7 @@ python3 {{SCRIPT_PATH}} "beauty spa wellness service" --design-system -p "Sereni
 To save the design system for hierarchical retrieval across sessions, add `--persist`:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name"
 ```
 
 This creates:
@@ -74,7 +91,7 @@ This creates:
 
 **With page-specific override:**
 ```bash
-python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+python3 <skill_dir>/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
 ```
 
 This also creates:
@@ -90,7 +107,7 @@ This also creates:
 After getting the design system, use domain searches to get additional details:
 
 ```bash
-python3 {{SCRIPT_PATH}} "<keyword>" --domain <domain> [-n <max_results>]
+python3 <skill_dir>/scripts/search.py "<keyword>" --domain <domain> [-n <max_results>]
 ```
 
 **When to use detailed searches:**
@@ -108,7 +125,7 @@ python3 {{SCRIPT_PATH}} "<keyword>" --domain <domain> [-n <max_results>]
 Get implementation-specific best practices. If user doesn't specify a stack, **default to `html-tailwind`**.
 
 ```bash
-python3 {{SCRIPT_PATH}} "<keyword>" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "<keyword>" --stack html-tailwind
 ```
 
 Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`
@@ -162,7 +179,7 @@ Available stacks: `html-tailwind`, `react`, `nextjs`, `vue`, `svelte`, `swiftui`
 ### Step 2: Generate Design System (REQUIRED)
 
 ```bash
-python3 {{SCRIPT_PATH}} "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
+python3 <skill_dir>/scripts/search.py "beauty spa wellness service elegant" --design-system -p "Serenity Spa"
 ```
 
 **Output:** Complete design system with pattern, style, colors, typography, effects, and anti-patterns.
@@ -171,16 +188,16 @@ python3 {{SCRIPT_PATH}} "beauty spa wellness service elegant" --design-system -p
 
 ```bash
 # Get UX guidelines for animation and accessibility
-python3 {{SCRIPT_PATH}} "animation accessibility" --domain ux
+python3 <skill_dir>/scripts/search.py "animation accessibility" --domain ux
 
 # Get alternative typography options if needed
-python3 {{SCRIPT_PATH}} "elegant luxury serif" --domain typography
+python3 <skill_dir>/scripts/search.py "elegant luxury serif" --domain typography
 ```
 
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 {{SCRIPT_PATH}} "layout responsive form" --stack html-tailwind
+python3 <skill_dir>/scripts/search.py "layout responsive form" --stack html-tailwind
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -193,10 +210,10 @@ The `--design-system` flag supports two output formats:
 
 ```bash
 # ASCII box (default) - best for terminal display
-python3 {{SCRIPT_PATH}} "fintech crypto" --design-system
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system
 
 # Markdown - best for documentation
-python3 {{SCRIPT_PATH}} "fintech crypto" --design-system -f markdown
+python3 <skill_dir>/scripts/search.py "fintech crypto" --design-system -f markdown
 ```
 
 ---


### PR DESCRIPTION
## Summary

Replace hardcoded `skills/ui-ux-pro-max/scripts/search.py` paths with a portable `<skill_dir>/scripts/search.py` placeholder across SKILL.md and its template sources.

## Problem

All `python3` commands in SKILL.md use a hardcoded relative path:

```bash
python3 skills/ui-ux-pro-max/scripts/search.py "query" --design-system
```

This assumes the skill is installed in the project's `skills/` subdirectory. When installed elsewhere (common with user-level installations), the AI agent gets "file not found" errors:

| Installation location | Works? |
|---|---|
| `skills/ui-ux-pro-max/` (project) | ✅ |
| `.claude/skills/ui-ux-pro-max/` (Claude Code project) | ❌ |
| `~/.claude/skills/ui-ux-pro-max/` (Claude Code user) | ❌ |
| `~/.agents/skills/ui-ux-pro-max/` (OpenCode) | ❌ |
| `.shared/ui-ux-pro-max/` (Cursor/Windsurf) | ❌ |

**Note:** The Python scripts themselves are fine — `core.py` uses `Path(__file__).parent.parent / "data"` for data resolution. The problem is only in the SKILL.md instructions that tell the AI *how to invoke* the scripts.

## Fix

1. **Added a "Skill Location" section** before Prerequisites that:
   - Lists common installation paths across AI tools
   - Provides a `find` command to auto-detect the skill directory
   - Explains that `<skill_dir>` is used as a placeholder throughout

2. **Replaced all 12 hardcoded paths** with `<skill_dir>/scripts/search.py`

3. **Updated all three copies** of the content:
   - `.claude/skills/ui-ux-pro-max/SKILL.md` (generated file)
   - `src/ui-ux-pro-max/templates/base/skill-content.md` (source of truth)
   - `cli/assets/templates/base/skill-content.md` (CLI bundled copy)

## Scope

- Only documentation/template files modified
- No Python code changes (scripts already handle paths correctly)
- No CLI code changes