### PR TITLE
fix: add error context to JSON.parse in loadPlatformConfig

### DIFF
--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -64,7 +64,11 @@ export async function loadPlatformConfig(aiType: string): Promise<PlatformConfig
 
   const configPath = join(ASSETS_DIR, 'templates', 'platforms', `${platformName}.json`);
   const content = await readFile(configPath, 'utf-8');
-  return JSON.parse(content) as PlatformConfig;
+  try {
+    return JSON.parse(content) as PlatformConfig;
+  } catch (e) {
+    throw new Error(`Invalid JSON in platform config "${platformName}.json": ${(e as Error).message}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

`loadPlatformConfig()` calls `JSON.parse(content)` on the raw contents of a platform config file. If the file is malformed (corrupted download, manual edit typo, encoding issue), `JSON.parse` throws a generic `SyntaxError` like:

```
SyntaxError: Unexpected token } in JSON at position 42
```

This gives no indication of *which* platform config file failed, making debugging difficult — especially when `loadAllPlatformConfigs()` iterates over all platforms.

## Fix

Wrap `JSON.parse` in a try/catch that re-throws with the platform name included:

```
Invalid JSON in platform config "react.json": Unexpected token } in JSON at position 42
```

**1 file changed, 5 insertions, 1 deletion.**