### PR TITLE
feat(roocode): add missing frontmatter

### DIFF
--- a/src/ui-ux-pro-max/templates/platforms/roocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/roocode.json
@@ -8,7 +8,10 @@
     "filename": "SKILL.md"
   },
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
-  "frontmatter": null,
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks."
+  },
   "sections": {
     "quickReference": false
   },


### PR DESCRIPTION
As the doc says roocode need the forntmatters https://docs.roocode.com/features/slash-commands?_highlight=slash

Maybe should also change the define from workflow to skill? 