### PR TITLE
feat(cli): add optional GitHub token support and actionable rate-limit guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,21 @@ uipro init --ai all         # All assistants
 ### Other CLI Commands
 
 ```bash
-uipro versions              # List available versions
-uipro update                # Update to latest version
-uipro init --offline        # Skip GitHub download, use bundled assets
+uipro versions --token <token>  # List available versions with token (optional)
+uipro update --token <token>    # Update to latest version with token (optional)
+uipro init --offline                   # Skip GitHub download, use bundled assets
+
+# Or set env var once
+export UI_PRO_MAX_GITHUB_TOKEN=github_xxx
 ```
+
+**Where to get a token**
+
+Create a Personal Access Token in GitHub:
+
+- GitHub → **Settings** → **Developer settings** → **Personal access tokens**
+- Recommended: create a token with the minimum scopes you need (for public repo release reads, no extra scopes are typically required).
+
 
 ## Prerequisites
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,17 +28,28 @@ uipro init --ai continue    # Continue (Skills)
 uipro init --ai all         # All assistants
 
 # Options
-uipro init --offline        # Skip GitHub download, use bundled assets only
-uipro init --force          # Overwrite existing files
+uipro init --offline                    # Skip GitHub download, use bundled assets only
+uipro init --force                      # Overwrite existing files
+uipro init --token <token>       # Optional GitHub token to avoid API rate limits
 
 # Other commands
-uipro versions              # List available versions
-uipro update                # Update to latest version
+uipro versions --token <token>   # List available versions (optional token)
+uipro update --token <token>     # Update to latest version (optional token)
+
+# Env var
+export UI_PRO_MAX_GITHUB_TOKEN=github_xxx
 ```
+
+## Where to get a token
+
+Create a Personal Access Token in GitHub:
+
+- GitHub → **Settings** → **Developer settings** → **Personal access tokens**
+- Recommended: create a token with the minimum scopes you need (for public repo release reads, no extra scopes are typically required).
 
 ## How It Works
 
-By default, `uipro init` tries to download the latest release from GitHub to ensure you get the most up-to-date version. If the download fails (network error, rate limit), it automatically falls back to the bundled assets included in the CLI package.
+By default, `uipro init` uses template generation locally. In ZIP download mode (`--legacy`), it tries to download the latest release from GitHub, and if that fails (network error, rate limit), it automatically falls back to the bundled assets included in the CLI package. If you hit GitHub rate limits, pass optional `--token` or set `UI_PRO_MAX_GITHUB_TOKEN`.
 
 Use `--offline` to skip the GitHub download and use bundled assets directly.
 

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
   downloadRelease,
   GitHubRateLimitError,
   GitHubDownloadError,
+  getGitHubTokenGuidance,
 } from '../utils/github.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,6 +27,7 @@ interface InitOptions {
   force?: boolean;
   offline?: boolean;
   legacy?: boolean; // Use old ZIP-based install
+  githubToken?: string;
 }
 
 /**
@@ -35,13 +37,14 @@ interface InitOptions {
 async function tryGitHubInstall(
   targetDir: string,
   aiType: AIType,
-  spinner: ReturnType<typeof ora>
+  spinner: ReturnType<typeof ora>,
+  options: InitOptions
 ): Promise<string[] | null> {
   let tempDir: string | null = null;
 
   try {
     spinner.text = 'Fetching latest release from GitHub...';
-    const release = await getLatestRelease();
+    const release = await getLatestRelease({ token: options.githubToken });
     const assetUrl = getAssetUrl(release);
 
     if (!assetUrl) {
@@ -52,7 +55,7 @@ async function tryGitHubInstall(
     tempDir = await createTempDir();
     const zipPath = join(tempDir, 'release.zip');
 
-    await downloadRelease(assetUrl, zipPath);
+    await downloadRelease(assetUrl, zipPath, { token: options.githubToken });
 
     spinner.text = 'Extracting and installing files...';
     const { copiedFolders, tempDir: extractedTempDir } = await installFromZip(
@@ -72,7 +75,7 @@ async function tryGitHubInstall(
     }
 
     if (error instanceof GitHubRateLimitError) {
-      spinner.warn('GitHub rate limit reached, using template generation...');
+      spinner.warn(`GitHub rate limit reached. ${getGitHubTokenGuidance()} Falling back to template generation...`);
       return null;
     }
 
@@ -154,7 +157,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
     if (options.legacy) {
       // Try GitHub download first (unless offline mode)
       if (!options.offline) {
-        const githubResult = await tryGitHubInstall(cwd, aiType, spinner);
+        const githubResult = await tryGitHubInstall(cwd, aiType, spinner, options);
         if (githubResult) {
           copiedFolders = githubResult;
           installMethod = 'github';

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,12 +1,13 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { getLatestRelease } from '../utils/github.js';
+import { getLatestRelease, GitHubRateLimitError } from '../utils/github.js';
 import { logger } from '../utils/logger.js';
 import { initCommand } from './init.js';
 import type { AIType } from '../types/index.js';
 
 interface UpdateOptions {
   ai?: AIType;
+  githubToken?: string;
 }
 
 export async function updateCommand(options: UpdateOptions): Promise<void> {
@@ -15,7 +16,7 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
   const spinner = ora('Checking for updates...').start();
 
   try {
-    const release = await getLatestRelease();
+    const release = await getLatestRelease({ token: options.githubToken });
     spinner.succeed(`Latest version: ${chalk.cyan(release.tag_name)}`);
 
     console.log();
@@ -25,9 +26,14 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
     await initCommand({
       ai: options.ai,
       force: true,
+      githubToken: options.githubToken,
     });
   } catch (error) {
     spinner.fail('Update check failed');
+    if (error instanceof GitHubRateLimitError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
     if (error instanceof Error) {
       logger.error(error.message);
     }

--- a/cli/src/commands/versions.ts
+++ b/cli/src/commands/versions.ts
@@ -1,13 +1,17 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { fetchReleases } from '../utils/github.js';
+import { fetchReleases, GitHubRateLimitError } from '../utils/github.js';
 import { logger } from '../utils/logger.js';
 
-export async function versionsCommand(): Promise<void> {
+interface VersionsOptions {
+  githubToken?: string;
+}
+
+export async function versionsCommand(options: VersionsOptions = {}): Promise<void> {
   const spinner = ora('Fetching available versions...').start();
 
   try {
-    const releases = await fetchReleases();
+    const releases = await fetchReleases({ token: options.githubToken });
 
     if (releases.length === 0) {
       spinner.warn('No releases found');
@@ -34,6 +38,10 @@ export async function versionsCommand(): Promise<void> {
     logger.dim('Use: uipro init --version <tag> to install a specific version');
   } catch (error) {
     spinner.fail('Failed to fetch versions');
+    if (error instanceof GitHubRateLimitError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
     if (error instanceof Error) {
       logger.error(error.message);
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ program
   .command('init')
   .description('Install UI/UX Pro Max skill to current project')
   .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
+  .option('--token <token>', 'GitHub token to avoid API rate limits (optional)')
   .option('-f, --force', 'Overwrite existing files')
   .option('-o, --offline', 'Skip GitHub download, use bundled assets only')
   .action(async (options) => {
@@ -37,18 +38,25 @@ program
       ai: options.ai as AIType | undefined,
       force: options.force,
       offline: options.offline,
+      githubToken: options.token,
     });
   });
 
 program
   .command('versions')
   .description('List available versions')
-  .action(versionsCommand);
+  .option('--token <token>', 'GitHub token to avoid API rate limits (optional)')
+  .action(async (options) => {
+    await versionsCommand({
+      githubToken: options.token,
+    });
+  });
 
 program
   .command('update')
   .description('Update UI/UX Pro Max to latest version')
   .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
+  .option('--token <token>', 'GitHub token to avoid API rate limits (optional)')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
       console.error(`Invalid AI type: ${options.ai}`);
@@ -57,6 +65,7 @@ program
     }
     await updateCommand({
       ai: options.ai as AIType | undefined,
+      githubToken: options.token,
     });
   });
 

--- a/cli/src/utils/github.ts
+++ b/cli/src/utils/github.ts
@@ -5,6 +5,10 @@ const REPO_OWNER = 'nextlevelbuilder';
 const REPO_NAME = 'ui-ux-pro-max-skill';
 const API_BASE = 'https://api.github.com';
 
+interface GitHubRequestOptions {
+  token?: string;
+}
+
 export class GitHubRateLimitError extends Error {
   constructor(message: string) {
     super(message);
@@ -19,26 +23,45 @@ export class GitHubDownloadError extends Error {
   }
 }
 
+export function getGitHubTokenGuidance(): string {
+  return 'To avoid rate limits, re-run with --token <token> or set UI_PRO_MAX_GITHUB_TOKEN. Create a GitHub Personal Access Token in Settings -> Developer settings -> Personal access tokens.';
+}
+
+function resolveGitHubToken(token?: string): string | undefined {
+  return token || process.env.UI_PRO_MAX_GITHUB_TOKEN;
+}
+
+function createGitHubHeaders(accept: string, token?: string): Record<string, string> {
+  const resolvedToken = resolveGitHubToken(token);
+  const headers: Record<string, string> = {
+    'Accept': accept,
+    'User-Agent': 'uipro-cli',
+  };
+
+  if (resolvedToken) {
+    headers['Authorization'] = `Bearer ${resolvedToken}`;
+  }
+
+  return headers;
+}
+
 function checkRateLimit(response: Response): void {
   const remaining = response.headers.get('x-ratelimit-remaining');
   if (response.status === 403 && remaining === '0') {
     const resetTime = response.headers.get('x-ratelimit-reset');
     const resetDate = resetTime ? new Date(parseInt(resetTime) * 1000).toLocaleTimeString() : 'unknown';
-    throw new GitHubRateLimitError(`GitHub API rate limit exceeded. Resets at ${resetDate}`);
+    throw new GitHubRateLimitError(`GitHub API rate limit exceeded. Resets at ${resetDate}. ${getGitHubTokenGuidance()}`);
   }
   if (response.status === 429) {
-    throw new GitHubRateLimitError('GitHub API rate limit exceeded (429 Too Many Requests)');
+    throw new GitHubRateLimitError(`GitHub API rate limit exceeded (429 Too Many Requests). ${getGitHubTokenGuidance()}`);
   }
 }
 
-export async function fetchReleases(): Promise<Release[]> {
+export async function fetchReleases(options: GitHubRequestOptions = {}): Promise<Release[]> {
   const url = `${API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/releases`;
 
   const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'uipro-cli',
-    },
+    headers: createGitHubHeaders('application/vnd.github.v3+json', options.token),
   });
 
   checkRateLimit(response);
@@ -50,14 +73,11 @@ export async function fetchReleases(): Promise<Release[]> {
   return response.json();
 }
 
-export async function getLatestRelease(): Promise<Release> {
+export async function getLatestRelease(options: GitHubRequestOptions = {}): Promise<Release> {
   const url = `${API_BASE}/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
 
   const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'uipro-cli',
-    },
+    headers: createGitHubHeaders('application/vnd.github.v3+json', options.token),
   });
 
   checkRateLimit(response);
@@ -69,12 +89,9 @@ export async function getLatestRelease(): Promise<Release> {
   return response.json();
 }
 
-export async function downloadRelease(url: string, dest: string): Promise<void> {
+export async function downloadRelease(url: string, dest: string, options: GitHubRequestOptions = {}): Promise<void> {
   const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'uipro-cli',
-      'Accept': 'application/octet-stream',
-    },
+    headers: createGitHubHeaders('application/octet-stream', options.token),
   });
 
   checkRateLimit(response);


### PR DESCRIPTION
## Motivation

GitHub API rate limits can sometimes cause failures when listing or downloading releases.  
This PR adds optional authentication support and clearer guidance to help users resolve rate-limit issues.

## Changes

- Added optional `--token <token>` to:
  - `uipro init`
  - `uipro versions`
  - `uipro update`
- Pass token through command handlers and GitHub request helpers to set the `Authorization` header.
- Improved rate-limit messaging:
  - Centralized guidance in `getGitHubTokenGuidance()`
  - Included guidance in `403` / `429` responses
  - Added init fallback warning before template fallback
- Updated README with:
  - `--token` usage examples
  - `UI_PRO_MAX_GITHUB_TOKEN` environment variable
  - Instructions for creating a GitHub PAT and suggested minimum scope

## Behavior

- Token usage is **optional**; existing workflows continue to work without it.
- Default install remains **template-based**.
- ZIP download mode is available via `--legacy`.

## Validation

- CLI builds successfully (`bun run build`)
- Verified command wiring and documentation updates through source inspection