### PR TITLE
fix(cli): add 'droid' to valid AI types

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uipro-cli",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {
@@ -28,6 +28,7 @@
     "roocode",
     "codex",
     "qoder",
+    "droid",
     "ai",
     "skill"
   ],


### PR DESCRIPTION
## Summary
- Bump CLI version from 2.2.3 to 2.2.4 to include `droid` AI type support in the published npm package
- Add `droid` to package.json keywords

## Why
The README documents `uipro init --ai droid` as a supported command, but the published npm package (v2.2.3) rejects it with "Invalid AI type: droid".

**Root cause:** The source code already has full `droid` support (type definition, `AI_TYPES` array, `AI_FOLDERS` mapping, detection logic, platform template, and config). However, the npm package v2.2.3 was published **before** these additions were made — the compiled `dist/index.js` in the published tarball has `AI_TYPES` without `droid`.

The fix is a version bump to 2.2.4 so that the next `npm publish` rebuilds `dist/` from the current source and includes `droid`.

Closes #172

## Test plan
- [x] Verified `droid` is in `AI_TYPES` array (`cli/src/types/index.ts`)
- [x] Verified `droid` is in `AI_FOLDERS` mapping (`cli/src/types/index.ts`)
- [x] Verified `droid` detection in `cli/src/utils/detect.ts`
- [x] Verified `droid` description in `getAITypeDescription` (`cli/src/utils/detect.ts`)
- [x] Verified `droid` in `AI_TO_PLATFORM` mapping (`cli/src/utils/template.ts`)
- [x] Verified `cli/assets/templates/platforms/droid.json` exists
- [x] Confirmed published npm tarball v2.2.3 is missing `droid` from compiled `AI_TYPES`
- [x] After version bump and rebuild, `uipro init --ai droid` will no longer return an error
- [x] Other AI types unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)