### PR TITLE
fix: use .agents/skills path for Antigravity (align with spec)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ out/
 .claude/settings.local.json
 .claude/session-state/
 ui-ux-pro-max-website/*
+.agents/

--- a/cli/assets/templates/platforms/agent.json
+++ b/cli/assets/templates/platforms/agent.json
@@ -3,7 +3,7 @@
   "displayName": "Antigravity / Generic Agent",
   "installType": "full",
   "folderStructure": {
-    "root": ".agent",
+    "root": ".agents",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -48,7 +48,7 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   claude: ['.claude'],
   cursor: ['.cursor', '.shared'],
   windsurf: ['.windsurf', '.shared'],
-  antigravity: ['.agent', '.shared'],
+  antigravity: ['.agents', '.agent', '.shared'],
   copilot: ['.github', '.shared'],
   kiro: ['.kiro', '.shared'],
   codex: ['.codex'],

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -19,7 +19,7 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.windsurf'))) {
     detected.push('windsurf');
   }
-  if (existsSync(join(cwd, '.agent'))) {
+  if (existsSync(join(cwd, '.agents')) || existsSync(join(cwd, '.agent'))) {
     detected.push('antigravity');
   }
   if (existsSync(join(cwd, '.github'))) {

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -76,7 +76,7 @@ export function getAITypeDescription(aiType: AIType): string {
     case 'windsurf':
       return 'Windsurf (.windsurf/skills/)';
     case 'antigravity':
-      return 'Antigravity (.agent/skills/)';
+      return 'Antigravity (.agents/skills/)';
     case 'copilot':
       return 'GitHub Copilot (.github/prompts/)';
     case 'kiro':

--- a/src/ui-ux-pro-max/templates/platforms/agent.json
+++ b/src/ui-ux-pro-max/templates/platforms/agent.json
@@ -3,7 +3,7 @@
   "displayName": "Antigravity / Generic Agent",
   "installType": "full",
   "folderStructure": {
-    "root": ".agent",
+    "root": ".agents",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },


### PR DESCRIPTION
### 🐛 Fix Antigravity skills path mismatch

#### Issue

The CLI currently installs Antigravity skills to:

```
<workspace>/.agent/skills/
```

However, according to official Antigravity documentation, the correct path is:

```
<workspace>/.agents/skills/
```

#### Evidence

* Antigravity docs specify `.agents/skills`
* CLI currently uses `.agent/skills`
* This creates a mismatch between expected and actual skill locations

#### Fix

* Updated Antigravity platform root from `.agent` → `.agents`
* Updated CLI detection label accordingly

#### Scope

This change only affects the Antigravity platform configuration and does not impact other integrations (Claude, Cursor, Gemini, etc.).

#### Testing

* Built CLI locally
* Ran `init --ai antigravity`
* Verified `.agents/` directory is created correctly in a fresh workspace

---

Happy to add backward compatibility for `.agent` if needed.
