### PR TITLE
Improve CLI troubleshooting for AI type/frontmatter issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,25 @@ uipro uninstall --ai claude # Remove specific platform
 uipro uninstall --global    # Remove from global install
 ```
 
+### CLI Troubleshooting
+
+If you see `Invalid AI type: trae` or `Invalid AI type: droid`, your global CLI is usually outdated.
+
+```bash
+uipro --version
+npm install -g uipro-cli@latest
+```
+
+If RooCode / Kiro generated `SKILL.md` appears to miss frontmatter metadata (`name`, `description`), upgrade and reinstall for those platforms:
+
+```bash
+npm install -g uipro-cli@latest
+uipro uninstall --ai roocode
+uipro uninstall --ai kiro
+uipro init --ai roocode
+uipro init --ai kiro
+```
+
 ## Prerequisites
 
 Python 3.x is required for the search script.

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,6 +36,37 @@ uipro versions              # List available versions
 uipro update                # Update to latest version
 ```
 
+## Troubleshooting
+
+### `Invalid AI type: trae` / `Invalid AI type: droid`
+
+This usually means your global CLI is outdated.
+
+```bash
+# 1) Check installed version
+uipro --version
+
+# 2) Upgrade to latest
+npm install -g uipro-cli@latest
+
+# 3) Retry
+uipro init --ai trae
+# or
+uipro init --ai droid
+```
+
+### RooCode / Kiro generated `SKILL.md` has missing frontmatter
+
+If generated files seem to miss metadata fields (for example `name` / `description`), reinstall with the latest CLI and regenerate:
+
+```bash
+npm install -g uipro-cli@latest
+uipro uninstall --ai roocode
+uipro uninstall --ai kiro
+uipro init --ai roocode
+uipro init --ai kiro
+```
+
 ## How It Works
 
 By default, `uipro init` tries to download the latest release from GitHub to ensure you get the most up-to-date version. If the download fails (network error, rate limit), it automatically falls back to the bundled assets included in the CLI package.

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target node",
     "dev": "bun run src/index.ts",
+    "verify:platform-configs": "node scripts/verify-platform-configs.mjs",
     "prepublishOnly": "bun run build"
   },
   "keywords": [

--- a/cli/scripts/verify-platform-configs.mjs
+++ b/cli/scripts/verify-platform-configs.mjs
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, '..');
+
+async function readJSON(path) {
+  const raw = await readFile(path, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function verifyAITypeCoverage() {
+  const typesPath = join(cliRoot, 'src', 'types', 'index.ts');
+  const content = await readFile(typesPath, 'utf-8');
+  assert(content.includes("'trae'"), "AI type 'trae' is missing in cli/src/types/index.ts");
+  assert(content.includes("'droid'"), "AI type 'droid' is missing in cli/src/types/index.ts");
+}
+
+async function verifyFrontmatter(platform) {
+  const configPath = join(cliRoot, 'assets', 'templates', 'platforms', `${platform}.json`);
+  const config = await readJSON(configPath);
+  assert(config.frontmatter && typeof config.frontmatter === 'object', `${platform} frontmatter is missing`);
+  assert(typeof config.frontmatter.name === 'string' && config.frontmatter.name.length > 0, `${platform} frontmatter.name is missing`);
+  assert(typeof config.frontmatter.description === 'string' && config.frontmatter.description.length > 0, `${platform} frontmatter.description is missing`);
+}
+
+async function main() {
+  await verifyAITypeCoverage();
+  await verifyFrontmatter('roocode');
+  await verifyFrontmatter('kiro');
+  console.log('Platform config verification passed (trae/droid + roocode/kiro frontmatter).');
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,6 +17,14 @@ const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8')
 
 const program = new Command();
 
+function printInvalidAITypeError(input: string): void {
+  console.error(`Invalid AI type: ${input}`);
+  console.error(`Valid types: ${AI_TYPES.join(', ')}`);
+  console.error('Tip: your uipro-cli may be outdated. Run: uipro --version');
+  console.error('Then upgrade: npm install -g uipro-cli@latest');
+  console.error('After upgrading, retry: uipro init --ai <type>');
+}
+
 program
   .name('uipro')
   .description('CLI to install UI/UX Pro Max skill for AI coding assistants')
@@ -31,8 +39,7 @@ program
   .option('-g, --global', 'Install globally to home directory (~/) instead of current project')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
-      console.error(`Invalid AI type: ${options.ai}`);
-      console.error(`Valid types: ${AI_TYPES.join(', ')}`);
+      printInvalidAITypeError(options.ai);
       process.exit(1);
     }
     await initCommand({
@@ -54,8 +61,7 @@ program
   .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
-      console.error(`Invalid AI type: ${options.ai}`);
-      console.error(`Valid types: ${AI_TYPES.join(', ')}`);
+      printInvalidAITypeError(options.ai);
       process.exit(1);
     }
     await updateCommand({
@@ -70,8 +76,7 @@ program
   .option('-g, --global', 'Uninstall from home directory (~/) instead of current project')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
-      console.error(`Invalid AI type: ${options.ai}`);
-      console.error(`Valid types: ${AI_TYPES.join(', ')}`);
+      printInvalidAITypeError(options.ai);
       process.exit(1);
     }
     await uninstallCommand({


### PR DESCRIPTION
## Summary

This PR addresses issue reports around:
- `Invalid AI type: trae` / `Invalid AI type: droid` (e.g. #195, #172)
- Missing frontmatter in generated RooCode/Kiro `SKILL.md` (e.g. #212)

### What changed

1. **Improved invalid AI type error guidance**
   - Added a shared `printInvalidAITypeError()` helper in `cli/src/index.ts`.
   - Updated `init`, `update`, and `uninstall` command validation paths to use it.
   - Error output now includes explicit upgrade guidance:
     - `uipro --version`
     - `npm install -g uipro-cli@latest`
     - retry command

2. **Added CLI troubleshooting docs**
   - Added troubleshooting section in `cli/README.md` for:
     - `Invalid AI type: trae/droid`
     - RooCode/Kiro frontmatter regeneration steps
   - Added matching troubleshooting section in root `README.md` for quick visibility.

3. **Added platform config verification script**
   - New script: `cli/scripts/verify-platform-configs.mjs`
   - Verifies:
     - `trae` and `droid` are present in `cli/src/types/index.ts`
     - `roocode` and `kiro` platform configs contain non-empty frontmatter (`name`, `description`)
   - Added npm script:
     - `verify:platform-configs` in `cli/package.json`

## Testing

- `npm --prefix cli run verify:platform-configs`
- `npm --prefix cli run build`
- `node cli/dist/index.js init --ai not-real`

## Related Issues

- #212
- #195
- #172