### PR TITLE
fix(cli): generate correct script path for Claude SKILL commands

### DIFF
--- a/cli/assets/templates/base/skill-content.md
+++ b/cli/assets/templates/base/skill-content.md
@@ -60,7 +60,7 @@ Extract key information from user request:
 **Always start with `--design-system`** to get comprehensive recommendations with reasoning:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
+python3 {{SCRIPT_PATH}} "<product_type> <industry> <keywords>" --design-system [-p "Project Name"]
 ```
 
 This command:
@@ -71,7 +71,7 @@ This command:
 
 **Example:**
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --design-system -p "Serenity Spa"
+python3 {{SCRIPT_PATH}} "beauty spa wellness service" --design-system -p "Serenity Spa"
 ```
 
 ### Step 2b: Persist Design System (Master + Overrides Pattern)
@@ -79,7 +79,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "beauty spa wellness service" --d
 To save the design system for **hierarchical retrieval across sessions**, add `--persist`:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name"
+python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name"
 ```
 
 This creates:
@@ -88,7 +88,7 @@ This creates:
 
 **With page-specific override:**
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "Project Name" --page "dashboard"
+python3 {{SCRIPT_PATH}} "<query>" --design-system --persist -p "Project Name" --page "dashboard"
 ```
 
 This also creates:
@@ -113,7 +113,7 @@ Now, generate the code...
 After getting the design system, use domain searches to get additional details:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n <max_results>]
+python3 {{SCRIPT_PATH}} "<keyword>" --domain <domain> [-n <max_results>]
 ```
 
 **When to use detailed searches:**
@@ -136,7 +136,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 Get React Native implementation-specific best practices:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
+python3 {{SCRIPT_PATH}} "<keyword>" --stack react-native
 ```
 
 ---
@@ -179,7 +179,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 ### Step 2: Generate Design System (REQUIRED)
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "AI search tool modern minimal" --design-system -p "AI Search"
+python3 {{SCRIPT_PATH}} "AI search tool modern minimal" --design-system -p "AI Search"
 ```
 
 **Output:** Complete design system with pattern, style, colors, typography, effects, and anti-patterns.
@@ -188,16 +188,16 @@ python3 skills/ui-ux-pro-max/scripts/search.py "AI search tool modern minimal" -
 
 ```bash
 # Get style options for a modern tool product
-python3 skills/ui-ux-pro-max/scripts/search.py "minimalism dark mode" --domain style
+python3 {{SCRIPT_PATH}} "minimalism dark mode" --domain style
 
 # Get UX best practices for search interaction and loading
-python3 skills/ui-ux-pro-max/scripts/search.py "search loading animation" --domain ux
+python3 {{SCRIPT_PATH}} "search loading animation" --domain ux
 ```
 
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react-native
+python3 {{SCRIPT_PATH}} "list performance navigation" --stack react-native
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -210,10 +210,10 @@ The `--design-system` flag supports two output formats:
 
 ```bash
 # ASCII box (default) - best for terminal display
-python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system
+python3 {{SCRIPT_PATH}} "fintech crypto" --design-system
 
 # Markdown - best for documentation
-python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system -f markdown
+python3 {{SCRIPT_PATH}} "fintech crypto" --design-system -f markdown
 ```
 
 ---

--- a/cli/assets/templates/platforms/claude.json
+++ b/cli/assets/templates/platforms/claude.json
@@ -7,7 +7,7 @@
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },
-  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "scriptPath": "scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
     "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 15 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."


### PR DESCRIPTION
## Summary
Fix generated SKILL command paths so Claude users can run `search.py` from the skill folder directly.

## Issue selection / triage
I targeted **#181** and first verified there was **no existing PR resolving it**:
- searched PRs referencing `#181` / `181` in title/body → none found.

## Root cause
The base template had hardcoded commands like:
- `python3 skills/ui-ux-pro-max/scripts/search.py ...`

But users run commands from inside the skill directory (e.g. `~/.claude/skills/ui-ux-pro-max`), where the correct path is:
- `python3 scripts/search.py ...`

That mismatch causes “file not found” behavior reported in #181 (and similar path-related confusion).

## Changes
- `cli/assets/templates/base/skill-content.md`
  - replace hardcoded `python3 skills/ui-ux-pro-max/scripts/search.py ...`
  - with `python3 {{SCRIPT_PATH}} ...` in all command examples.
- `cli/assets/templates/platforms/claude.json`
  - set `scriptPath` to `scripts/search.py` (correct when run from skill dir).

## Manual verification (Docker)
To avoid host pollution, I verified using Docker (`oven/bun:1.2`):
1. Build CLI
2. Run `init --ai claude --offline`
3. Inspect generated `.claude/skills/ui-ux-pro-max/SKILL.md`

Result: generated commands now consistently use:
- `python3 scripts/search.py ...`

which matches the installed folder layout.

Closes #181
