### PR TITLE
Replace primitive tokens with Andritz industrial design values

### DIFF
--- a/.claude/skills/design-system/references/primitive-tokens.md
+++ b/.claude/skills/design-system/references/primitive-tokens.md
@@ -1,41 +1,65 @@
-# Primitive Tokens
+# Primitive Tokens — Andritz Precision
 
-Raw design values - foundation of the design system.
+Raw design values for industrial precision design system with dark/light themes.
 
 ## Color Scales
 
-### Gray Scale
+### Andritz Blue Scale
 
 ```css
 :root {
-  --color-gray-50:  #F9FAFB;
-  --color-gray-100: #F3F4F6;
-  --color-gray-200: #E5E7EB;
-  --color-gray-300: #D1D5DB;
-  --color-gray-400: #9CA3AF;
-  --color-gray-500: #6B7280;
-  --color-gray-600: #4B5563;
-  --color-gray-700: #374151;
-  --color-gray-800: #1F2937;
-  --color-gray-900: #111827;
-  --color-gray-950: #030712;
+  --andritz-blue-900: #001c38;
+  --andritz-blue-800: #003258;
+  --andritz-blue-700: #004a77;
+  --andritz-blue-600: #005c97;
+  --andritz-blue-500: #0075be;
+  --andritz-blue-400: #4d9fd4;
+  --andritz-blue-300: #9bcaff;
+  --andritz-blue-200: #c6dfff;
+  --andritz-blue-100: #e0efff;
+  --andritz-blue-50:  #f0f7ff;
 }
 ```
 
-### Primary Colors (Blue)
+### Surface Scale (Light Theme)
 
 ```css
 :root {
-  --color-blue-50:  #EFF6FF;
-  --color-blue-100: #DBEAFE;
-  --color-blue-200: #BFDBFE;
-  --color-blue-300: #93C5FD;
-  --color-blue-400: #60A5FA;
-  --color-blue-500: #3B82F6;
-  --color-blue-600: #2563EB;
-  --color-blue-700: #1D4ED8;
-  --color-blue-800: #1E40AF;
-  --color-blue-900: #1E3A8A;
+  --surface-lowest:  #ffffff;
+  --surface-low:     #f8fafb;
+  --surface-base:    #f2f4f5;
+  --surface-mid:     #eceeef;
+  --surface-high:    #e6e8e9;
+  --surface-highest: #e1e3e4;
+}
+```
+
+### Surface Scale (Dark Theme)
+
+```css
+:root {
+  --surface-dark-lowest:  #0a0e14;
+  --surface-dark-low:     #10141a;
+  --surface-dark-base:    #181c22;
+  --surface-dark-mid:     #1c2026;
+  --surface-dark-high:    #262a31;
+  --surface-dark-highest: #31353c;
+}
+```
+
+### Neutral Scale
+
+```css
+:root {
+  --neutral-950: #001c38;  /* deepest black — replaces pure #000000 */
+  --neutral-900: #191c1d;
+  --neutral-700: #404751;
+  --neutral-600: #49607f;
+  --neutral-500: #4b5a69;
+  --neutral-300: #c0c7d2;
+  --neutral-200: #dfe2eb;
+  --neutral-100: #eef1f6;
+  --neutral-50:  #f5f7fa;
 }
 ```
 
@@ -43,26 +67,31 @@ Raw design values - foundation of the design system.
 
 ```css
 :root {
-  /* Success - Green */
-  --color-green-500: #22C55E;
-  --color-green-600: #16A34A;
+  /* Error */
+  --color-error-600: #ba1a1a;
+  --color-error-400: #ff6b6b;
+  --color-error-300: #ffb4ab;
+  --color-error-100: #ffdad6;
+  --color-on-error: #ffffff;
 
-  /* Warning - Yellow */
-  --color-yellow-500: #EAB308;
-  --color-yellow-600: #CA8A04;
+  /* Warning / Tertiary (Caution Tape) */
+  --color-tertiary-500: #ffb781;
+  --color-tertiary-400: #ffc9a0;
+  --color-tertiary-200: #ffe4cc;
 
-  /* Error - Red */
-  --color-red-500: #EF4444;
-  --color-red-600: #DC2626;
+  /* Success */
+  --color-success-600: #1a8a4a;
+  --color-success-400: #4ade80;
+  --color-success-100: #dcfce7;
 
-  /* Info - Blue */
-  --color-info: var(--color-blue-500);
+  /* Info */
+  --color-info: var(--andritz-blue-300);
 }
 ```
 
 ## Spacing Scale
 
-4px base unit system.
+8px grid base, extreme whitespace philosophy.
 
 ```css
 :root {
@@ -71,95 +100,101 @@ Raw design values - foundation of the design system.
   --space-0-5: 0.125rem;  /* 2px */
   --space-1:   0.25rem;   /* 4px */
   --space-1-5: 0.375rem;  /* 6px */
-  --space-2:   0.5rem;    /* 8px */
-  --space-2-5: 0.625rem;  /* 10px */
+  --space-2:   0.5rem;    /* 8px - base unit */
   --space-3:   0.75rem;   /* 12px */
-  --space-3-5: 0.875rem;  /* 14px */
   --space-4:   1rem;      /* 16px */
   --space-5:   1.25rem;   /* 20px */
-  --space-6:   1.5rem;    /* 24px */
-  --space-7:   1.75rem;   /* 28px */
-  --space-8:   2rem;      /* 32px */
-  --space-9:   2.25rem;   /* 36px */
+  --space-6:   1.5rem;    /* 24px - component gap */
+  --space-8:   2rem;      /* 32px - zone separation */
   --space-10:  2.5rem;    /* 40px */
-  --space-12:  3rem;      /* 48px */
-  --space-14:  3.5rem;    /* 56px */
+  --space-12:  3rem;      /* 48px - section gap */
   --space-16:  4rem;      /* 64px */
-  --space-20:  5rem;      /* 80px */
+  --space-20:  5rem;      /* 80px - extreme whitespace */
   --space-24:  6rem;      /* 96px */
+  --space-32:  8rem;      /* 128px - hero spacing */
 }
 ```
 
 ## Typography Scale
 
+Blueprint Scale — engineered type hierarchy for industrial dashboards.
+
 ```css
 :root {
-  /* Font Sizes */
-  --font-size-xs:   0.75rem;   /* 12px */
-  --font-size-sm:   0.875rem;  /* 14px */
-  --font-size-base: 1rem;      /* 16px */
-  --font-size-lg:   1.125rem;  /* 18px */
-  --font-size-xl:   1.25rem;   /* 20px */
-  --font-size-2xl:  1.5rem;    /* 24px */
-  --font-size-3xl:  1.875rem;  /* 30px */
-  --font-size-4xl:  2.25rem;   /* 36px */
-  --font-size-5xl:  3rem;      /* 48px */
+  /* Font Families */
+  --font-family-primary: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-family-premium: 'Gilroy', 'Inter', system-ui, sans-serif;
+
+  /* Display — "stamped metal" KPIs */
+  --font-size-display-lg: 3.5rem;   /* 56px */
+  --font-size-display-md: 2.75rem;  /* 44px */
+  --font-size-display-sm: 2.25rem;  /* 36px */
+
+  /* Headline — structural beams */
+  --font-size-headline-lg: 2rem;     /* 32px */
+  --font-size-headline-md: 1.75rem;  /* 28px */
+  --font-size-headline-sm: 1.5rem;   /* 24px */
+
+  /* Title — navigation/card headers */
+  --font-size-title-lg: 1.375rem;  /* 22px */
+  --font-size-title-md: 1.125rem;  /* 18px */
+  --font-size-title-sm: 1rem;      /* 16px */
+
+  /* Body — high-density data */
+  --font-size-body-lg: 1rem;      /* 16px */
+  --font-size-body-md: 0.875rem;  /* 14px */
+  --font-size-body-sm: 0.75rem;   /* 12px */
+
+  /* Label — ALL CAPS machined look */
+  --font-size-label-md: 0.75rem;   /* 12px */
+  --font-size-label-sm: 0.6875rem; /* 11px */
 
   /* Line Heights */
-  --leading-none:   1;
-  --leading-tight:  1.25;
-  --leading-snug:   1.375;
-  --leading-normal: 1.5;
+  --leading-none:    1;
+  --leading-tight:   1.2;
+  --leading-snug:    1.35;
+  --leading-normal:  1.5;
   --leading-relaxed: 1.625;
-  --leading-loose:  2;
 
   /* Font Weights */
-  --font-weight-normal:   400;
+  --font-weight-regular:  400;
   --font-weight-medium:   500;
   --font-weight-semibold: 600;
   --font-weight-bold:     700;
 
   /* Letter Spacing */
-  --tracking-tighter: -0.05em;
-  --tracking-tight:   -0.025em;
-  --tracking-normal:  0;
-  --tracking-wide:    0.025em;
-  --tracking-wider:   0.05em;
+  --tracking-tight:    -0.02em;  /* headlines — "technical manual" */
+  --tracking-normal:   0;
+  --tracking-wide:     0.05em;   /* labels — "machined" look */
+  --tracking-wider:    0.1em;    /* display pairs — engineering drawing */
 }
 ```
 
 ## Border Radius
 
+Industrial Precision — 0px is the rule.
+
 ```css
 :root {
-  --radius-none:    0;
-  --radius-sm:      0.125rem;  /* 2px */
-  --radius-default: 0.25rem;   /* 4px */
-  --radius-md:      0.375rem;  /* 6px */
-  --radius-lg:      0.5rem;    /* 8px */
-  --radius-xl:      0.75rem;   /* 12px */
-  --radius-2xl:     1rem;      /* 16px */
-  --radius-3xl:     1.5rem;    /* 24px */
-  --radius-full:    9999px;
+  --radius-none: 0;      /* DEFAULT — used everywhere */
+  --radius-full: 9999px; /* Only for status indicators/avatars */
+  /* NO other radius values — 0px is the rule */
 }
 ```
 
 ## Shadows
 
+Ambient only — no drop shadows, no layered elevation.
+
 ```css
 :root {
   --shadow-none: none;
-  --shadow-sm:   0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-default: 0 1px 3px 0 rgb(0 0 0 / 0.1),
-                    0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --shadow-md:   0 4px 6px -1px rgb(0 0 0 / 0.1),
-                 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg:   0 10px 15px -3px rgb(0 0 0 / 0.1),
-                 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --shadow-xl:   0 20px 25px -5px rgb(0 0 0 / 0.1),
-                 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --shadow-2xl:  0 25px 50px -12px rgb(0 0 0 / 0.25);
-  --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+  --shadow-ambient-light: 0px 12px 32px 0px rgba(0, 28, 56, 0.06);
+  --shadow-ambient-dark:  0px 12px 32px 0px rgba(0, 28, 56, 0.4);
+  --shadow-glow-primary:  0px 0px 8px var(--andritz-blue-300); /* dark theme pulse line */
+  /* Ghost border fallback (not a shadow, but listed here for elevation) */
+  --ghost-border-light: 1px solid rgba(192, 199, 210, 0.15);  /* outline-variant 15% */
+  --ghost-border-dark:  1px solid rgba(64, 71, 81, 0.20);     /* outline-variant 20% */
 }
 ```
 
@@ -173,13 +208,15 @@ Raw design values - foundation of the design system.
   --duration-200: 200ms;
   --duration-300: 300ms;
   --duration-500: 500ms;
-  --duration-700: 700ms;
-  --duration-1000: 1000ms;
 
   /* Semantic durations */
   --duration-fast:   var(--duration-150);
   --duration-normal: var(--duration-200);
   --duration-slow:   var(--duration-300);
+
+  /* Easing */
+  --ease-standard: ease-in-out;
+  --ease-decelerate: ease-out;
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replaced all generic primitive tokens (Tailwind-based gray/blue scales, generic shadows, rounded border radii) with Andritz-specific industrial precision values
- Added Andritz Blue 10-step scale, light/dark surface scales, neutral scale, and semantic status colors (error, warning, success, info)
- Switched to 8px grid spacing with extreme whitespace philosophy, blueprint typography scale with Inter/Gilroy font families, industrial 0px border radius, and ambient-only shadows
- Added dark theme support with dedicated surface and shadow tokens, glow effects, and ghost border fallbacks

## Test plan
- [x] Verified no leftover generic tokens (#2563EB, gray-50: #F9FAFB, blue-600: #2563EB)
- [x] Confirmed all seven sections present: Color Scales, Spacing, Typography, Border Radius, Shadows, Motion, Z-Index
- [x] Z-Index scale preserved as-is (not brand-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)