### PR TITLE
fix: validate plugin names in tailwind config generator to prevent RCE

### DIFF
--- a/.claude/skills/ui-styling/scripts/tailwind_config_gen.py
+++ b/.claude/skills/ui-styling/scripts/tailwind_config_gen.py
@@ -8,9 +8,15 @@ Supports colors, fonts, spacing, breakpoints, and plugin recommendations.
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+# Valid npm package name pattern: optional @scope/, then package name with
+# optional subpath. Only allows alphanumeric, hyphens, dots, underscores,
+# and forward slashes — no quotes, parens, or semicolons.
+_VALID_PLUGIN_NAME = re.compile(r'^(@[a-zA-Z0-9_-]+/)?[a-zA-Z0-9_-]+(/[a-zA-Z0-9_.-]+)*$')
 
 
 class TailwindConfigGenerator:
@@ -230,13 +236,24 @@ module.exports = {{
 """
 
     def _format_plugins(self) -> str:
-        """Format plugins array for config."""
+        """Format plugins array for config.
+
+        Validates each plugin name against a strict allowlist pattern
+        to prevent code injection via crafted require() statements
+        (see: CWE-94).
+        """
         if not self.config["plugins"]:
             return ""
 
-        plugin_requires = [
-            f"require('{plugin}')" for plugin in self.config["plugins"]
-        ]
+        plugin_requires = []
+        for plugin in self.config["plugins"]:
+            if not _VALID_PLUGIN_NAME.match(plugin):
+                raise ValueError(
+                    f"Invalid plugin name: {plugin!r}. "
+                    "Plugin names must be valid npm package names "
+                    "(e.g. '@tailwindcss/typography')."
+                )
+            plugin_requires.append(f"require('{plugin}')")
         return ", ".join(plugin_requires)
 
     def _indent_json(self, json_str: str, level: int) -> str:


### PR DESCRIPTION
## Summary

Fixes the **Code Injection → RCE vulnerability** (CVSS 9.3, Critical) in `tailwind_config_gen.py` reported in #246.

The `_format_plugins()` method interpolated plugin names directly into JavaScript `require('...')` statements without any sanitization. A plugin name containing a single quote (e.g. `fs').writeFileSync(...)`) could break out of the `require()` call and inject arbitrary JavaScript that executes when Node.js loads the generated `tailwind.config.js`.

### Fix

- Add a strict regex allowlist (`^(@[a-zA-Z0-9_-]+/)?[a-zA-Z0-9_-]+(/[a-zA-Z0-9_.-]+)*$`) that matches valid npm package name patterns
- Reject any plugin name that doesn't match **before** generating output, raising a `ValueError` with a descriptive message
- This blocks all injection vectors: single quotes, parentheses, semicolons, backticks, etc.

### Testing

| Input | Result |
|---|---|
| `@tailwindcss/typography` | Accepted |
| `tailwindcss-animate` | Accepted |
| `some-plugin/sub-path` | Accepted |
| `fs').writeFileSync('/tmp/rce','PWNED'),require('fs` | **Rejected** with ValueError |
| `legit'); process.exit(1); //` | **Rejected** with ValueError |

Normal config generation with valid plugins produces identical output — no regressions.

Closes #246