### PR TITLE
feat: add GitHub Copilot CLI platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ uipro init --ai cursor      # Cursor
 uipro init --ai windsurf    # Windsurf
 uipro init --ai antigravity # Antigravity
 uipro init --ai copilot     # GitHub Copilot
-uipro init --ai copilot-cli # GitHub Copilot Coding Agent
+uipro init --ai copilot-cli # GitHub Copilot CLI
 uipro init --ai kiro        # Kiro
 uipro init --ai codex       # Codex CLI
 uipro init --ai qoder       # Qoder
@@ -334,7 +334,7 @@ winget install Python.Python.3.12
 
 ### Skill Mode (Auto-activate)
 
-**Supported:** Claude Code, Cursor, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, GitHub Copilot Coding Agent, OpenCode, Qoder, CodeBuddy, Droid (Factory), KiloCode, Warp, Augment
+**Supported:** Claude Code, Cursor, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, GitHub Copilot CLI, OpenCode, Qoder, CodeBuddy, Droid (Factory), KiloCode, Warp, Augment
 
 The skill activates automatically when you request UI/UX work. Just chat naturally:
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ uipro init --ai cursor      # Cursor
 uipro init --ai windsurf    # Windsurf
 uipro init --ai antigravity # Antigravity
 uipro init --ai copilot     # GitHub Copilot
+uipro init --ai copilot-cli # GitHub Copilot Coding Agent
 uipro init --ai kiro        # Kiro
 uipro init --ai codex       # Codex CLI
 uipro init --ai qoder       # Qoder
@@ -333,7 +334,7 @@ winget install Python.Python.3.12
 
 ### Skill Mode (Auto-activate)
 
-**Supported:** Claude Code, Cursor, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, OpenCode, Qoder, CodeBuddy, Droid (Factory), KiloCode, Warp, Augment
+**Supported:** Claude Code, Cursor, Windsurf, Antigravity, Codex CLI, Continue, Gemini CLI, GitHub Copilot Coding Agent, OpenCode, Qoder, CodeBuddy, Droid (Factory), KiloCode, Warp, Augment
 
 The skill activates automatically when you request UI/UX work. Just chat naturally:
 

--- a/cli/assets/templates/platforms/copilot-cli.json
+++ b/cli/assets/templates/platforms/copilot-cli.json
@@ -1,6 +1,6 @@
 {
   "platform": "copilot-cli",
-  "displayName": "GitHub Copilot (Coding Agent)",
+  "displayName": "GitHub Copilot CLI",
   "installType": "full",
   "folderStructure": {
     "root": ".github",

--- a/cli/assets/templates/platforms/copilot-cli.json
+++ b/cli/assets/templates/platforms/copilot-cli.json
@@ -1,0 +1,18 @@
+{
+  "platform": "copilot-cli",
+  "displayName": "GitHub Copilot (Coding Agent)",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".github",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": null,
+  "sections": {
+    "quickReference": false
+  },
+  "title": "ui-ux-pro-max",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'all';
+export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'copilot-cli' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'all';
 
 export type InstallType = 'full' | 'reference';
 
@@ -41,7 +41,7 @@ export interface PlatformConfig {
   skillOrWorkflow: string;
 }
 
-export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'all'];
+export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'copilot-cli', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'all'];
 
 // Legacy folder mapping for backward compatibility with ZIP-based installs.
 // Note: .shared is included for platforms that used ZIP installs. Post-ZIP platforms
@@ -52,6 +52,7 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   windsurf: ['.windsurf', '.shared'],
   antigravity: ['.agents', '.shared'],
   copilot: ['.github', '.shared'],
+  'copilot-cli': ['.github'],
   kiro: ['.kiro', '.shared'],
   codex: ['.codex'],
   roocode: ['.roo', '.shared'],

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -25,6 +25,9 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.github'))) {
     detected.push('copilot');
   }
+  if (existsSync(join(cwd, '.github', 'copilot-instructions.md'))) {
+    detected.push('copilot-cli');
+  }
   if (existsSync(join(cwd, '.kiro'))) {
     detected.push('kiro');
   }
@@ -88,6 +91,8 @@ export function getAITypeDescription(aiType: AIType): string {
       return 'Antigravity (.agents/skills/)';
     case 'copilot':
       return 'GitHub Copilot (.github/prompts/)';
+    case 'copilot-cli':
+      return 'GitHub Copilot Coding Agent (.github/skills/)';
     case 'kiro':
       return 'Kiro (.kiro/steering/)';
     case 'codex':

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -92,7 +92,7 @@ export function getAITypeDescription(aiType: AIType): string {
     case 'copilot':
       return 'GitHub Copilot (.github/prompts/)';
     case 'copilot-cli':
-      return 'GitHub Copilot Coding Agent (.github/skills/)';
+      return 'GitHub Copilot CLI (.github/skills/)';
     case 'kiro':
       return 'Kiro (.kiro/steering/)';
     case 'codex':

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -33,6 +33,7 @@ const AI_TO_PLATFORM: Record<string, string> = {
   windsurf: 'windsurf',
   antigravity: 'agent',
   copilot: 'copilot',
+  'copilot-cli': 'copilot-cli',
   kiro: 'kiro',
   opencode: 'opencode',
   roocode: 'roocode',

--- a/skill.json
+++ b/skill.json
@@ -22,6 +22,7 @@
     "cursor",
     "windsurf",
     "copilot",
+    "copilot-cli",
     "kiro",
     "roocode",
     "kilocode",

--- a/src/ui-ux-pro-max/templates/platforms/copilot-cli.json
+++ b/src/ui-ux-pro-max/templates/platforms/copilot-cli.json
@@ -1,6 +1,6 @@
 {
   "platform": "copilot-cli",
-  "displayName": "GitHub Copilot (Coding Agent)",
+  "displayName": "GitHub Copilot CLI",
   "installType": "full",
   "folderStructure": {
     "root": ".github",

--- a/src/ui-ux-pro-max/templates/platforms/copilot-cli.json
+++ b/src/ui-ux-pro-max/templates/platforms/copilot-cli.json
@@ -1,0 +1,18 @@
+{
+  "platform": "copilot-cli",
+  "displayName": "GitHub Copilot (Coding Agent)",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".github",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": null,
+  "sections": {
+    "quickReference": false
+  },
+  "title": "ui-ux-pro-max",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}


### PR DESCRIPTION
The skill supports GitHub Copilot in VS Code (`.github/prompts/`) but not the GitHub Copilot CLI. This adds `copilot-cli` as a new platform type, installing to `.github/skills/ui-ux-pro-max/`.

### Changes

- **Platform config**: New `copilot-cli.json` in both `src/ui-ux-pro-max/templates/platforms/` and `cli/assets/templates/platforms/`
- **Type registration** (`cli/src/types/index.ts`): Added `copilot-cli` to `AIType`, `AI_TYPES`, and `AI_FOLDERS` (maps to `['.github']`)
- **Detection** (`cli/src/utils/detect.ts`): Auto-detects via `.github/copilot-instructions.md`
- **Template mapping** (`cli/src/utils/template.ts`): Added `AI_TO_PLATFORM` entry
- **README**: Added to install examples and supported platforms list

```bash
uipro init --ai copilot-cli   # GitHub Copilot CLI
```

### Tests
<img width="1428" height="404" alt="image" src="https://github.com/user-attachments/assets/30cf8bef-78b4-4a31-8192-cd304d84127b" />