### PR TITLE
docs: add Windows Python compatibility note

### DIFF
--- a/.claude/skills/banner-design/SKILL.md
+++ b/.claude/skills/banner-design/SKILL.md
@@ -21,6 +21,10 @@ Design banners across social, ads, web, and print formats. Generates multiple ar
 - Event/print banner design
 - Creative asset generation for campaigns
 
+## Prerequisites
+
+**Python:** This skill uses Python scripts. On Windows, use `python` instead of `python3` (e.g., `python scripts/search.py` instead of `python3 scripts/search.py`).
+
 ## Workflow
 
 ### Step 1: Gather Requirements (AskUserQuestion)

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -289,12 +289,23 @@ Load `references/social-photos-design.md` for sizes, templates, best practices.
 | `scripts/cip/core.py` | BM25 search engine for CIP data |
 | `scripts/icon/generate.py` | Generate SVG icons with Gemini 3.1 Pro |
 
+## Prerequisites
+
+**Python:** This skill uses Python scripts. On Windows, use `python` instead of `python3` (e.g., `python scripts/logo/search.py` instead of `python3 scripts/logo/search.py`).
+
+Check if Python is installed:
+```bash
+python3 --version || python --version
+```
+
 ## Setup
 
 ```bash
 export GEMINI_API_KEY="your-key"  # https://aistudio.google.com/apikey
 pip install google-genai pillow
 ```
+
+> **Note for Windows:** Use `python` instead of `pip` where needed (e.g., `python -m pip install ...`).
 
 ## Integration
 

--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -330,6 +330,8 @@ sudo apt update && sudo apt install python3
 winget install Python.Python.3.12
 ```
 
+> **Note:** On Windows, use `python` instead of `python3` to run scripts (e.g., `python scripts/search.py` instead of `python3 scripts/search.py`).
+
 ---
 
 ## How to Use This Skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ When modifying files:
 
 Python 3.x (no external dependencies required)
 
+**Note:** On Windows, use `python` instead of `python3` to run the scripts.
+
 ## Git Workflow
 
 Never push directly to `main`. Always:

--- a/src/ui-ux-pro-max/templates/base/skill-content.md
+++ b/src/ui-ux-pro-max/templates/base/skill-content.md
@@ -27,6 +27,8 @@ sudo apt update && sudo apt install python3
 winget install Python.Python.3.12
 ```
 
+> **Note:** On Windows, use `python` instead of `python3` to run scripts (e.g., `python scripts/search.py` instead of `python3 scripts/search.py`).
+
 ---
 
 ## How to Use This Skill


### PR DESCRIPTION
Add cross-platform Python command note to skills and docs:
- CLAUDE.md: Add Windows note in Prerequisites
- ui-ux-pro-max/SKILL.md: Add Windows note in Prerequisites
- design/SKILL.md: Add Prerequisites section with Windows note
- banner-design/SKILL.md: Add Prerequisites section with Windows note
- templates/base/skill-content.md: Add Windows note (source template)

Windows uses 'python' instead of 'python3' to run scripts.