### PR TITLE
fix: remove stale template variable from slides SKILL.md

### DIFF
--- a/.claude/skills/slides/SKILL.md
+++ b/.claude/skills/slides/SKILL.md
@@ -11,8 +11,6 @@ metadata:
 
 Strategic HTML presentation design with data visualization.
 
-<args>$ARGUMENTS</args>
-
 ## When to Use
 
 - Marketing presentations and pitch decks


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Line 14 of `.claude/skills/slides/SKILL.md` contains the raw template placeholder `<args>$ARGUMENTS</args>` that was never substituted during generation. This renders as literal XML-like text in the skill body. When Claude Code loads the skill, this tag is included as-is in the context, which can confuse the LLM into treating the text as a special tag or trying to substitute `$ARGUMENTS` itself.

## Fix

Removed the unsubstituted `<args>$ARGUMENTS</args>` line. Arguments are already available to the LLM via the invocation context — no explicit placeholder is needed in the skill body.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-stale-template","fingerprint":"sha256:1ccc6d7c8e050e29a3087d9ef10740d5b43b9aed4f17740296f52e9d115c23e7"}]}
nlpm-metadata-end -->