### PR TITLE
fix: replace execSync template string with execFileSync in sync-brand-to-tokens.cjs

### DIFF
--- a/.claude/skills/brand/scripts/sync-brand-to-tokens.cjs
+++ b/.claude/skills/brand/scripts/sync-brand-to-tokens.cjs
@@ -11,7 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 // Paths
 const BRAND_GUIDELINES = 'docs/brand-guidelines.md';
@@ -250,7 +250,7 @@ function main() {
   const generateScript = path.resolve(process.cwd(), GENERATE_TOKENS_SCRIPT);
   if (fs.existsSync(generateScript)) {
     try {
-      execSync(`node ${generateScript} --config ${DESIGN_TOKENS_JSON} -o ${DESIGN_TOKENS_CSS}`, {
+      execFileSync('node', [generateScript, '--config', DESIGN_TOKENS_JSON, '-o', DESIGN_TOKENS_CSS], {
         cwd: process.cwd(),
         stdio: 'inherit'
       });


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium)

\`.claude/skills/brand/scripts/sync-brand-to-tokens.cjs\` line 253 uses \`execSync\` with a backtick template string:

\`\`\`js
execSync(\`node \${generateScript} --config \${DESIGN_TOKENS_JSON} -o \${DESIGN_TOKENS_CSS}\`, { ... })
\`\`\`

All three interpolated variables (\`generateScript\`, \`DESIGN_TOKENS_JSON\`, \`DESIGN_TOKENS_CSS\`) are currently hardcoded constants, so there is no active injection risk. However, the pattern is fragile: if any future change passes user-controlled data through one of those paths, a shell injection vulnerability would be introduced without any obvious signal.

**Fix:** Replace with \`execFileSync('node', [generateScript, '--config', DESIGN_TOKENS_JSON, '-o', DESIGN_TOKENS_CSS], { ... })\`. The array form never invokes a shell, so the expansion surface is eliminated entirely. Import updated from \`execSync\` to \`execFileSync\`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-shell-true","fingerprint":"sha256:3b2dc21792abe9222fed3a26d01b6bfdcde65fac8eba7f3db9da9f29d410acdb"}]}
nlpm-metadata-end -->