### PR TITLE
fix: pin shadcn version instead of @latest in shadcn_add.py

### DIFF
--- a/.claude/skills/ui-styling/scripts/shadcn_add.py
+++ b/.claude/skills/ui-styling/scripts/shadcn_add.py
@@ -64,6 +64,20 @@ class ShadcnInstaller:
         except (json.JSONDecodeError, KeyError, OSError):
             return []
 
+    def _get_shadcn_version(self) -> str:
+        """Read shadcn version from project package.json; fall back to a pinned default."""
+        pkg_json = self.project_root / "package.json"
+        if pkg_json.exists():
+            try:
+                pkg = json.loads(pkg_json.read_text())
+                for section in ("dependencies", "devDependencies"):
+                    version = pkg.get(section, {}).get("shadcn")
+                    if version:
+                        return version.lstrip("^~>=<").split()[0]
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return "2.3.0"  # pinned fallback; update when newer stable release is needed
+
     def add_components(
         self, components: List[str], overwrite: bool = False
     ) -> tuple[bool, str]:
@@ -98,7 +112,8 @@ class ShadcnInstaller:
             )
 
         # Build command
-        cmd = ["npx", "shadcn@latest", "add"] + components
+        shadcn_version = self._get_shadcn_version()
+        cmd = ["npx", f"shadcn@{shadcn_version}", "add"] + components
 
         if overwrite:
             cmd.append("--overwrite")
@@ -144,7 +159,8 @@ class ShadcnInstaller:
                 "shadcn not initialized. Run 'npx shadcn@latest init' first",
             )
 
-        cmd = ["npx", "shadcn@latest", "add", "--all"]
+        shadcn_version = self._get_shadcn_version()
+        cmd = ["npx", f"shadcn@{shadcn_version}", "add", "--all"]
 
         if overwrite:
             cmd.append("--overwrite")


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium)

\`.claude/skills/ui-styling/scripts/shadcn_add.py\` calls \`npx shadcn@latest add\` which silently downloads and runs whatever version npm has tagged as \`latest\` at the time of each invocation. While list-form \`subprocess.run\` prevents shell injection, the package itself is unverified at runtime — a supply-chain compromise of the \`shadcn\` npm package would be automatically installed on the next run.

**Fix:** Add a \`_get_shadcn_version()\` helper that:
1. Reads the project's \`package.json\` and returns the \`shadcn\` version from \`dependencies\` or \`devDependencies\` if present
2. Falls back to a pinned version string (\`2.3.0\`) when the project does not declare one

This ensures installations are reproducible. The pinned fallback version in the helper comment makes the version visible and easy to update deliberately.

Applied to both \`add_components()\` and \`add_all_components()\`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:3c24cc56309b9f06223a90749116fe7042f25f8f2e080e1d70316ba45f26fb2f"}]}
nlpm-metadata-end -->