### PR TITLE
fix: add SHA-256 checksum verification to release download (security)

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -13,6 +13,7 @@ import {
   getLatestRelease,
   getAssetUrl,
   downloadRelease,
+  findChecksumAsset,
   GitHubRateLimitError,
   GitHubDownloadError,
 } from '../utils/github.js';
@@ -53,7 +54,9 @@ async function tryGitHubInstall(
     tempDir = await createTempDir();
     const zipPath = join(tempDir, 'release.zip');
 
-    await downloadRelease(assetUrl, zipPath);
+    const assetFileName = assetUrl.split('/').pop() ?? 'release.zip';
+    const expectedSha256 = await findChecksumAsset(release, assetFileName);
+    await downloadRelease(assetUrl, zipPath, expectedSha256 ?? undefined);
 
     spinner.text = 'Extracting and installing files...';
     const { copiedFolders, tempDir: extractedTempDir } = await installFromZip(

--- a/cli/src/utils/github.ts
+++ b/cli/src/utils/github.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import type { Release } from '../types/index.js';
 
@@ -69,7 +70,7 @@ export async function getLatestRelease(): Promise<Release> {
   return response.json();
 }
 
-export async function downloadRelease(url: string, dest: string): Promise<void> {
+export async function downloadRelease(url: string, dest: string, expectedSha256?: string): Promise<void> {
   const response = await fetch(url, {
     headers: {
       'User-Agent': 'uipro-cli',
@@ -84,7 +85,35 @@ export async function downloadRelease(url: string, dest: string): Promise<void> 
   }
 
   const buffer = await response.arrayBuffer();
+
+  if (expectedSha256) {
+    const actual = createHash('sha256').update(Buffer.from(buffer)).digest('hex');
+    if (actual !== expectedSha256) {
+      throw new GitHubDownloadError(
+        `SHA-256 mismatch — download may be corrupted or tampered.
+Expected: ${expectedSha256}
+Actual:   ${actual}`
+      );
+    }
+  }
+
   await writeFile(dest, Buffer.from(buffer));
+}
+
+export async function findChecksumAsset(release: Release, assetName: string): Promise<string | null> {
+  const checksumNames = [`${assetName}.sha256`, 'checksums.sha256', 'SHA256SUMS'];
+  const checksumAsset = release.assets.find(a => checksumNames.includes(a.name));
+  if (!checksumAsset) return null;
+
+  const response = await fetch(checksumAsset.browser_download_url, {
+    headers: { 'User-Agent': 'uipro-cli' },
+  });
+  if (!response.ok) return null;
+
+  const text = await response.text();
+  // Format: "<hash>  <filename>" or just "<hash>"
+  const match = text.trim().match(/^([0-9a-f]{64})/m);
+  return match ? match[1] : null;
 }
 
 export function getAssetUrl(release: Release): string | null {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium severity)

`cli/src/utils/github.ts` — `downloadRelease()` fetches a ZIP from GitHub releases and writes it to disk, then `init.ts` extracts and copies the contents into the user's project. No integrity check was performed, so a compromised or corrupted release asset would be silently installed.

## Fix

**`cli/src/utils/github.ts`**

- Added an optional `expectedSha256` parameter to `downloadRelease()`. When provided, the downloaded buffer is hashed with Node's built-in `node:crypto` before writing to disk. A mismatch throws a `GitHubDownloadError` with both expected and actual hashes for easy diagnosis.
- Added `findChecksumAsset(release, assetName)` — looks for a companion checksum file in the GitHub release assets (`<assetName>.sha256`, `checksums.sha256`, `SHA256SUMS`) and extracts the hex digest.

**`cli/src/commands/init.ts`**

- Calls `findChecksumAsset()` before downloading.
- Passes the result to `downloadRelease()`.

**Backwards compatibility**: if the release does not include a checksum file, `findChecksumAsset` returns `null` and `downloadRelease` proceeds as before — no regression for existing releases.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-curl-pipe-sh","fingerprint":"sha256:76b2cad276a5e94538b0dab8bd77ebbd93f7e9b7fbbe123c2adb76d328153e07"}]}
nlpm-metadata-end -->