### PR TITLE
fix: remove unsubstituted template variable from slides/SKILL.md

### DIFF
--- a/.claude/skills/slides/SKILL.md
+++ b/.claude/skills/slides/SKILL.md
@@ -11,8 +11,6 @@ metadata:
 
 Strategic HTML presentation design with data visualization.
 
-<args>$ARGUMENTS</args>
-
 ## When to Use
 
 - Marketing presentations and pitch decks


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`.claude/skills/slides/SKILL.md` line 14 contains a raw template variable `<args>$ARGUMENTS</args>` that was never substituted. This appears to be a copy-paste artifact from a template generator — the placeholder was left in the rendered skill body instead of being removed or replaced.

**Why it matters:** When Claude Code loads this skill, the literal string `<args>$ARGUMENTS</args>` appears as part of the skill content. This can confuse LLM consumers into treating it as a tag or instruction, and may interfere with downstream parsers that process skill bodies.

**Fix:** Remove the two-line block (`<args>$ARGUMENTS</args>` and the trailing blank line). The arguments are already available to the LLM through the invocation context — the tag carries no information.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-stale-template","fingerprint":"sha256:1ccc6d7c8e050e29a3087d9ef10740d5b43b9aed4f17740296f52e9d115c23e7"}]}
nlpm-metadata-end -->