### PR TITLE
fix: add SHA-256 checksum verification to GitHub release downloads

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -12,9 +12,11 @@ import { logger } from '../utils/logger.js';
 import {
   getLatestRelease,
   getAssetUrl,
+  getChecksumUrl,
   downloadRelease,
   GitHubRateLimitError,
   GitHubDownloadError,
+  GitHubChecksumError,
 } from '../utils/github.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -52,8 +54,10 @@ async function tryGitHubInstall(
     spinner.text = `Downloading ${release.tag_name}...`;
     tempDir = await createTempDir();
     const zipPath = join(tempDir, 'release.zip');
+    const assetName = assetUrl.split('/').pop() ?? 'release.zip';
+    const checksumUrl = getChecksumUrl(release, assetName) ?? undefined;
 
-    await downloadRelease(assetUrl, zipPath);
+    await downloadRelease(assetUrl, zipPath, checksumUrl);
 
     spinner.text = 'Extracting and installing files...';
     const { copiedFolders, tempDir: extractedTempDir } = await installFromZip(
@@ -70,6 +74,10 @@ async function tryGitHubInstall(
     // Cleanup temp directory on error
     if (tempDir) {
       await cleanup(tempDir);
+    }
+
+    if (error instanceof GitHubChecksumError) {
+      throw error;
     }
 
     if (error instanceof GitHubRateLimitError) {

--- a/cli/src/utils/github.ts
+++ b/cli/src/utils/github.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import type { Release } from '../types/index.js';
 
@@ -16,6 +17,13 @@ export class GitHubDownloadError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'GitHubDownloadError';
+  }
+}
+
+export class GitHubChecksumError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitHubChecksumError';
   }
 }
 
@@ -69,7 +77,14 @@ export async function getLatestRelease(): Promise<Release> {
   return response.json();
 }
 
-export async function downloadRelease(url: string, dest: string): Promise<void> {
+export function getChecksumUrl(release: Release, assetName: string): string | null {
+  const checksumAsset = release.assets.find(
+    a => a.name === `${assetName}.sha256` || a.name === 'checksums.txt'
+  );
+  return checksumAsset?.browser_download_url ?? null;
+}
+
+export async function downloadRelease(url: string, dest: string, checksumUrl?: string): Promise<void> {
   const response = await fetch(url, {
     headers: {
       'User-Agent': 'uipro-cli',
@@ -84,6 +99,21 @@ export async function downloadRelease(url: string, dest: string): Promise<void> 
   }
 
   const buffer = await response.arrayBuffer();
+
+  if (checksumUrl) {
+    const checksumResponse = await fetch(checksumUrl, { headers: { 'User-Agent': 'uipro-cli' } });
+    if (checksumResponse.ok) {
+      const checksumText = (await checksumResponse.text()).trim();
+      const expectedHash = checksumText.split(/\s+/)[0];
+      const actualHash = createHash('sha256').update(Buffer.from(buffer)).digest('hex');
+      if (actualHash !== expectedHash) {
+        throw new GitHubChecksumError(
+          `Checksum mismatch for downloaded release: expected ${expectedHash}, got ${actualHash}`
+        );
+      }
+    }
+  }
+
   await writeFile(dest, Buffer.from(buffer));
 }
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium)

`cli/src/utils/github.ts` — `downloadRelease()` fetches a ZIP from GitHub releases and writes it directly to disk without any integrity check. `init.ts` then extracts and installs the contents into the user's project. A compromised release asset (e.g. from a hijacked GitHub token or a compromised release pipeline) would be silently installed with no way for the user to detect the tamper.

**Fix:** This PR adds opt-in SHA-256 verification using a companion checksum asset pattern:

1. `getChecksumUrl(release, assetName)` — looks for a `<asset-name>.sha256` or `checksums.txt` asset in the GitHub release
2. `downloadRelease(url, dest, checksumUrl?)` — if `checksumUrl` is provided and the fetch succeeds, computes `SHA-256` of the downloaded buffer and compares against the expected hash before writing to disk; throws `GitHubChecksumError` on mismatch
3. `init.ts` now calls `getChecksumUrl(release, assetName)` and passes the result to `downloadRelease`

**This is backward-compatible:** if no companion checksum asset is uploaded, the behavior is identical to the current code. To enable full verification, upload a `release.zip.sha256` (or `checksums.txt`) companion file to each GitHub release — the CLI will then automatically verify before installation.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-curl-pipe-sh","fingerprint":"sha256:76b2cad276a5e94538b0dab8bd77ebbd93f7e9b7fbbe123c2adb76d328153e07"}]}
nlpm-metadata-end -->