### PR TITLE
chore: update Bun lockfile metadata

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "uxpro-cli",


### PR DESCRIPTION
## Summary
- Regenerate `cli/bun.lock` using the current Bun version.
- Keep dependency installs reproducible across local environments.

## Test plan
- [x] Run `bun install` in `cli/`
- [x] Run `bun run build` in `cli/`

Made with [Cursor](https://cursor.com)