### PR TITLE
feat(cli): add init dry-run preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ uipro init --ai cursor --global   # Install to ~/.cursor/skills/
 uipro versions              # List available versions
 uipro update                # Update to latest version
 uipro init --offline        # Skip GitHub download, use bundled assets
+uipro init --dry-run        # Preview install actions without writing files
 uipro uninstall             # Remove skill (auto-detect platform)
 uipro uninstall --ai claude # Remove specific platform
 uipro uninstall --global    # Remove from global install
@@ -494,6 +495,7 @@ cp -r src/ui-ux-pro-max/templates/* cli/assets/templates/
 # 5. Build and test CLI
 cd cli && bun run build
 node dist/index.js init --ai claude --offline  # Test in a temp folder
+node dist/index.js init --ai claude --dry-run  # Preview install actions (no writes)
 
 # 6. Create PR (never push directly to main)
 git checkout -b feat/your-feature

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "uxpro-cli",

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -6,7 +6,12 @@ import prompts from 'prompts';
 import type { AIType } from '../types/index.js';
 import { AI_TYPES } from '../types/index.js';
 import { copyFolders, installFromZip, createTempDir, cleanup } from '../utils/extract.js';
-import { generatePlatformFiles, generateAllPlatformFiles } from '../utils/template.js';
+import {
+  generatePlatformFiles,
+  generateAllPlatformFiles,
+  planPlatformInstallActions,
+  planAllPlatformInstallActions,
+} from '../utils/template.js';
 import { detectAIType, getAITypeDescription } from '../utils/detect.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -27,6 +32,7 @@ interface InitOptions {
   offline?: boolean;
   legacy?: boolean; // Use old ZIP-based install
   global?: boolean; // Install to home directory (global mode)
+  dryRun?: boolean; // Preview actions without writing files
 }
 
 /**
@@ -147,8 +153,26 @@ export async function initCommand(options: InitOptions): Promise<void> {
   }
 
   const isGlobal = !!options.global;
+  const isDryRun = !!options.dryRun;
   const modeLabel = isGlobal ? ' (global)' : '';
-  logger.info(`Installing for: ${chalk.cyan(getAITypeDescription(aiType))}${modeLabel}`);
+  const verb = isDryRun ? 'Previewing install for' : 'Installing for';
+  logger.info(`${verb}: ${chalk.cyan(getAITypeDescription(aiType))}${modeLabel}`);
+
+  if (isDryRun) {
+    const cwd = process.cwd();
+    const actions = aiType === 'all'
+      ? await planAllPlatformInstallActions(cwd, isGlobal)
+      : await planPlatformInstallActions(cwd, aiType, isGlobal);
+
+    console.log();
+    logger.info('Planned actions (dry run):');
+    actions.forEach(action => {
+      console.log(`  ${chalk.cyan('•')} ${action}`);
+    });
+    console.log();
+    logger.success('Dry run completed. No files were written.');
+    return;
+  }
 
   const spinner = ora('Installing files...').start();
   const cwd = process.cwd();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -29,6 +29,7 @@ program
   .option('-f, --force', 'Overwrite existing files')
   .option('-o, --offline', 'Skip GitHub download, use bundled assets only')
   .option('-g, --global', 'Install globally to home directory (~/) instead of current project')
+  .option('--dry-run', 'Preview install actions without writing files')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
       console.error(`Invalid AI type: ${options.ai}`);
@@ -40,6 +41,7 @@ program
       force: options.force,
       offline: options.offline,
       global: options.global,
+      dryRun: options.dryRun,
     });
   });
 

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -235,6 +235,63 @@ export async function generateAllPlatformFiles(targetDir: string, isGlobal = fal
   return Array.from(allFolders);
 }
 
+function getSkillPaths(targetDir: string, config: PlatformConfig, isGlobal = false): {
+  effectiveDir: string;
+  skillDir: string;
+  skillFilePath: string;
+} {
+  const effectiveDir = isGlobal ? homedir() : targetDir;
+  const skillDir = join(
+    effectiveDir,
+    config.folderStructure.root,
+    config.folderStructure.skillPath
+  );
+  const skillFilePath = join(skillDir, config.folderStructure.filename);
+
+  return { effectiveDir, skillDir, skillFilePath };
+}
+
+/**
+ * Build a dry-run action list for one platform install
+ */
+export async function planPlatformInstallActions(
+  targetDir: string,
+  aiType: string,
+  isGlobal = false
+): Promise<string[]> {
+  const config = await loadPlatformConfig(aiType);
+  const { skillDir, skillFilePath } = getSkillPaths(targetDir, config, isGlobal);
+  const actions: string[] = [];
+
+  actions.push(`mkdir -p ${skillDir}`);
+  actions.push(`write ${skillFilePath}`);
+  actions.push(`copy ${join(ASSETS_DIR, 'data')} -> ${join(skillDir, 'data')}`);
+  actions.push(`copy ${join(ASSETS_DIR, 'scripts')} -> ${join(skillDir, 'scripts')}`);
+
+  return actions;
+}
+
+/**
+ * Build a dry-run action list for all platform installs
+ */
+export async function planAllPlatformInstallActions(
+  targetDir: string,
+  isGlobal = false
+): Promise<string[]> {
+  const actions: string[] = [];
+
+  for (const aiType of Object.keys(AI_TO_PLATFORM)) {
+    try {
+      const platformActions = await planPlatformInstallActions(targetDir, aiType, isGlobal);
+      actions.push(...platformActions);
+    } catch {
+      // Skip if planning fails for a platform
+    }
+  }
+
+  return actions;
+}
+
 /**
  * Get list of supported AI types
  */


### PR DESCRIPTION
## Summary
- add `--dry-run` option to `uipro init` to preview install operations without writing files
- print planned mkdir/write/copy actions for selected AI target (or all targets)
- document dry-run usage in README CLI commands and contributor test flow

## Test plan
- [x] `cd cli && bun run build`
- [x] `node dist/index.js init --ai claude --dry-run`
- [x] verify output shows planned actions and no files are created

Closes #291

Made with [Cursor](https://cursor.com)