### PR TITLE
Add openclaw to platforms list

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -35,7 +35,8 @@
     "droid",
     "warp",
     "augment",
-    "antigravity"
+    "antigravity",
+    "openclaw"
   ],
   "install": "npx uipro-cli init --ai {{platform}}"
 }


### PR DESCRIPTION
## Summary

Adds `openclaw` to the `platforms` array in `skill.json`.

## Why

[OpenClaw](https://openclaw.ai) is an open-source agent gateway / runtime that runs Claude as its primary backend. The skill works out-of-the-box inside OpenClaw agents — same `SKILL.md` + `python3 src/ui-ux-pro-max/scripts/search.py` invocation pattern as the other Claude-compatible platforms listed.

I'm running this skill inside OpenClaw locally (Mac mini, daily) and it's been useful — wanted to make the install flow target it explicitly.

## Test plan

- [x] `python3 src/ui-ux-pro-max/scripts/search.py "dashboard" --domain product` returns expected results inside an OpenClaw agent session
- [x] OpenClaw's `openclaw skills check` detects the skill via a small `SKILL.md` wrapper (no upstream change needed for that piece)

No code/data changes — just a single string added to the platforms list.