### PR TITLE
ci: add paths-ignore to skip docs-only CI runs

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,11 @@
 name: Python Package using Conda
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.claude/**'
 
 jobs:
   build-linux:


### PR DESCRIPTION
## What

Add `paths-ignore` to the `push` trigger in `python-package-conda.yml` so docs-only changes (`**/*.md`, `docs/**`, `.claude/**`) skip the Conda build/lint/test pipeline.

## Workflows changed

| Workflow | Change |
|----------|--------|
| `python-package-conda.yml` | Added `paths-ignore` to `push` trigger |

## Workflows deliberately LEFT

| Workflow | Reason |
|----------|--------|
| `claude.yml` | Event-driven bot triggered by issue/comment mentions (`@claude`) — path filters don't apply to comment events and could break bot invocation. Left untouched per hard rule. |
| `claude-code-review.yml` | PR bot triggered by PR open/sync events — path filters could suppress the review bot when docs-only PRs need a review. Left untouched per hard rule. |