### PR TITLE
fix(cli): correct misleading docs and remove nonexistent --version hint

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,9 +38,9 @@ uipro update                # Update to latest version
 
 ## How It Works
 
-By default, `uipro init` tries to download the latest release from GitHub to ensure you get the most up-to-date version. If the download fails (network error, rate limit), it automatically falls back to the bundled assets included in the CLI package.
+`uipro init` generates skill files from templates bundled inside the CLI package. This means installation works offline by default and does not require a network connection.
 
-Use `--offline` to skip the GitHub download and use bundled assets directly.
+Use `--offline` to make the offline behavior explicit (no-op with the current default, kept for clarity and future compatibility).
 
 ## Development
 

--- a/cli/src/commands/versions.ts
+++ b/cli/src/commands/versions.ts
@@ -31,7 +31,7 @@ export async function versionsCommand(): Promise<void> {
     });
 
     console.log();
-    logger.dim('Use: uipro init --version <tag> to install a specific version');
+    logger.dim('Run uipro update to reinstall the skill with the current bundled version.');
   } catch (error) {
     spinner.fail('Failed to fetch versions');
     if (error instanceof Error) {


### PR DESCRIPTION
## Problem

Two pieces of documentation describe behavior that doesn't match the code:

**1. `cli/README.md` — wrong install mechanism**

> "By default, `uipro init` tries to download the latest release from GitHub..."

The current default path (`init.ts:179-183`) uses `generatePlatformFiles()` — template generation from bundled assets. GitHub download only happens in the legacy ZIP mode (`init.ts:160`), which is not exposed as a CLI option. So `--offline` is currently a no-op relative to the default.

**2. `cli/src/commands/versions.ts:34` — advertises a nonexistent flag**

```
Use: uipro init --version <tag> to install a specific version
```

`--version` is not a registered option in `index.ts` for the `init` command. Running this would either use Commander's built-in `--version` (prints CLI version) or fail silently.

## Fix

- Rewrite "How It Works" in README to accurately describe template-based generation
- Replace the nonexistent `--version` hint in `versions.ts` with an accurate tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)