### PR TITLE
fix(cli): implement --force flag to protect existing skill files

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -101,17 +101,18 @@ async function templateInstall(
   targetDir: string,
   aiType: AIType,
   spinner: ReturnType<typeof ora>,
-  isGlobal = false
+  isGlobal = false,
+  force = false
 ): Promise<string[]> {
   spinner.text = isGlobal
     ? 'Generating skill files globally...'
     : 'Generating skill files from templates...';
 
   if (aiType === 'all') {
-    return generateAllPlatformFiles(targetDir, isGlobal);
+    return generateAllPlatformFiles(targetDir, isGlobal, force);
   }
 
-  return generatePlatformFiles(targetDir, aiType, isGlobal);
+  return generatePlatformFiles(targetDir, aiType, isGlobal, force);
 }
 
 export async function initCommand(options: InitOptions): Promise<void> {
@@ -178,7 +179,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
       }
     } else {
       // Use new template-based generation (default)
-      copiedFolders = await templateInstall(cwd, aiType, spinner, isGlobal);
+      copiedFolders = await templateInstall(cwd, aiType, spinner, isGlobal, options.force);
       installMethod = 'template';
     }
 

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -187,7 +187,8 @@ async function copyDataAndScripts(targetSkillDir: string): Promise<void> {
 export async function generatePlatformFiles(
   targetDir: string,
   aiType: string,
-  isGlobal = false
+  isGlobal = false,
+  force = false
 ): Promise<string[]> {
   const config = await loadPlatformConfig(aiType);
   const createdFolders: string[] = [];
@@ -208,6 +209,13 @@ export async function generatePlatformFiles(
   // Render and write skill file (pass isGlobal to adjust paths)
   const skillContent = await renderSkillFile(config, isGlobal);
   const skillFilePath = join(skillDir, config.folderStructure.filename);
+
+  const fileAlreadyExists = await exists(skillFilePath);
+  if (fileAlreadyExists && !force) {
+    console.log(`  Skipped (already exists): ${skillFilePath} — use --force to overwrite`);
+    return [];
+  }
+
   await writeFile(skillFilePath, skillContent, 'utf-8');
   createdFolders.push(config.folderStructure.root);
 
@@ -220,12 +228,12 @@ export async function generatePlatformFiles(
 /**
  * Generate files for all AI types
  */
-export async function generateAllPlatformFiles(targetDir: string, isGlobal = false): Promise<string[]> {
+export async function generateAllPlatformFiles(targetDir: string, isGlobal = false, force = false): Promise<string[]> {
   const allFolders = new Set<string>();
 
   for (const aiType of Object.keys(AI_TO_PLATFORM)) {
     try {
-      const folders = await generatePlatformFiles(targetDir, aiType, isGlobal);
+      const folders = await generatePlatformFiles(targetDir, aiType, isGlobal, force);
       folders.forEach(f => allFolders.add(f));
     } catch {
       // Skip if generation fails for a platform


### PR DESCRIPTION
## Problem

`--force` is registered in `index.ts` and described in the README, but has no effect. `template.ts` calls `writeFile()` unconditionally without checking whether the file already exists.

This means:
- Users running `uipro init` a second time silently overwrite their customized skill files
- The `--force` flag advertised in the README is misleading — it does nothing

## Fix

Add a file existence check in `generatePlatformFiles` before calling `writeFile`:

- If file exists and `--force` was not passed → skip with a clear message
- If file exists and `--force` was passed → overwrite (previous behavior for all cases)
- Propagate `force` through `generateAllPlatformFiles` → `templateInstall` → `initCommand`

## Behavior after this PR

```bash
uipro init --ai claude          # skips if SKILL.md already exists, prints warning
uipro init --ai claude --force  # overwrites regardless
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)