### PR TITLE
fix(cli): make uipro update actually upgrade the CLI via npm

### DIFF
--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,33 +1,36 @@
+import { execSync } from 'node:child_process';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getLatestRelease } from '../utils/github.js';
 import { logger } from '../utils/logger.js';
-import { initCommand } from './init.js';
-import type { AIType } from '../types/index.js';
 
-interface UpdateOptions {
-  ai?: AIType;
-}
-
-export async function updateCommand(options: UpdateOptions): Promise<void> {
+export async function updateCommand(): Promise<void> {
   logger.title('UI/UX Pro Max Updater');
 
-  const spinner = ora('Checking for updates...').start();
+  const spinner = ora('Checking latest version...').start();
 
   try {
     const release = await getLatestRelease();
-    spinner.succeed(`Latest version: ${chalk.cyan(release.tag_name)}`);
+    const latest = release.tag_name;
+    spinner.succeed(`Latest release: ${chalk.cyan(latest)}`);
+  } catch {
+    spinner.warn('Could not fetch latest release info. Proceeding with update anyway.');
+  }
 
-    console.log();
-    logger.info('Running update (same as init with latest version)...');
-    console.log();
+  console.log();
+  logger.info('Updating uipro-cli via npm...');
+  console.log();
 
-    await initCommand({
-      ai: options.ai,
-      force: true,
-    });
+  try {
+    execSync('npm install -g uipro-cli@latest', { stdio: 'inherit' });
+    console.log();
+    logger.success('uipro-cli updated successfully!');
+    console.log();
+    console.log(chalk.bold('Next steps:'));
+    console.log(chalk.dim('  Run: uipro init --ai <type> --force  to reinstall the skill'));
+    console.log();
   } catch (error) {
-    spinner.fail('Update check failed');
+    logger.error('npm install failed. Try manually: npm install -g uipro-cli@latest');
     if (error instanceof Error) {
       logger.error(error.message);
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -50,17 +50,9 @@ program
 
 program
   .command('update')
-  .description('Update UI/UX Pro Max to latest version')
-  .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
-  .action(async (options) => {
-    if (options.ai && !AI_TYPES.includes(options.ai)) {
-      console.error(`Invalid AI type: ${options.ai}`);
-      console.error(`Valid types: ${AI_TYPES.join(', ')}`);
-      process.exit(1);
-    }
-    await updateCommand({
-      ai: options.ai as AIType | undefined,
-    });
+  .description('Update uipro-cli to latest version via npm')
+  .action(async () => {
+    await updateCommand();
   });
 
 program


### PR DESCRIPTION
## Problem

`updateCommand` (`cli/src/commands/update.ts:25`) called `initCommand({force: true})` after showing the latest GitHub release tag. Since `initCommand` uses locally bundled assets by default, the actual CLI binary was never updated — only the skill files were reinstalled from the version already on disk.

A user running `uipro update` expecting a version bump received the same files they already had.

## Fix

Replace the body of `updateCommand` with a call to `npm install -g uipro-cli@latest` via `execSync`. This correctly upgrades both the CLI binary and its bundled assets.

- Still fetches latest release info to show the version (best-effort, non-blocking)
- Clear error message if npm fails
- Post-install guidance: `uipro init --ai <type> --force` to reinstall the skill
- Remove `--ai` option from `update` (was forwarded to initCommand which no longer drives update)

## Before / After

```bash
# Before: reinstalled same bundled assets, no CLI upgrade
uipro update

# After: runs npm install -g uipro-cli@latest
uipro update
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)