### PR TITLE
fix(meta): align marketplace.json and package-lock.json to v2.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,15 @@
     "name": "nextlevelbuilder"
   },
   "metadata": {
-    "description": "UI/UX design intelligence skill with 67 styles, 96 palettes, 57 font pairings, 25 charts, and 13 stack guidelines",
-    "version": "2.2.1"
+    "description": "UI/UX design intelligence skill with 67 styles, 161 palettes, 57 font pairings, 25 charts, and 15 stack guidelines",
+    "version": "2.5.0"
   },
   "plugins": [
     {
       "name": "ui-ux-pro-max",
       "source": "./",
       "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and Jetpack Compose.",
-      "version": "2.2.1",
+      "version": "2.5.0",
       "author": {
         "name": "nextlevelbuilder"
       },

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uipro-cli",
-  "version": "2.2.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uipro-cli",
-      "version": "2.2.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",


### PR DESCRIPTION
## Problem

Two files were stuck at `v2.2.1` while the rest of the project had moved to `v2.5.0`:

| File | Actual version | Expected |
|------|---------------|----------|
| `.claude-plugin/marketplace.json` | `2.2.1` | `2.5.0` |
| `cli/package-lock.json` | `2.2.1` | `2.5.0` |

The Claude marketplace reads `marketplace.json` for version and the description field. The stale entry showed `96 palettes` and `13 stacks` while the actual data contains 161 palettes and 15 stacks.

## Fix

- Bump `marketplace.json` metadata + plugin version to `2.5.0`
- Update palette/stack counts in description to match current data
- Align `package-lock.json` root version to `2.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)