### PR TITLE
Fix stack discovery in packaged skill assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Each rule includes:
 - **161 Color Palettes** - Industry-specific palettes aligned 1:1 with the 161 product types
 - **57 Font Pairings** - Curated typography combinations with Google Fonts imports
 - **25 Chart Types** - Recommendations for dashboards and analytics
-- **15 Tech Stacks** - React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, HTML+Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel
+- **Packaged Tech Stacks** - React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, HTML+Tailwind, shadcn/ui, Jetpack Compose, Three.js, Angular, Laravel
 - **99 UX Guidelines** - Best practices, anti-patterns, and accessibility rules
 - **161 Reasoning Rules** - Industry-specific design system generation (NEW in v2.0)
 

--- a/cli/assets/scripts/core.py
+++ b/cli/assets/scripts/core.py
@@ -81,9 +81,23 @@ def _discover_stack_config() -> Dict[str, Dict[str, str]]:
     Code Logic（这个函数做什么）:
         扫描 data/stacks 目录下的 CSV 文件，以文件名 stem 作为 stack 名称，生成 search_stack 使用的配置字典。
     """
+    stack_dir = DATA_DIR / "stacks"
+    if not stack_dir.is_dir():
+        raise RuntimeError(
+            f"Stack data directory not found: {stack_dir}. "
+            "Reinstall the skill or rebuild packaged assets."
+        )
+
+    stack_files = sorted(stack_dir.glob("*.csv"))
+    if not stack_files:
+        raise RuntimeError(
+            f"No stack CSV files found in: {stack_dir}. "
+            "Reinstall the skill or rebuild packaged assets."
+        )
+
     return {
         stack_file.stem: {"file": f"stacks/{stack_file.name}"}
-        for stack_file in sorted((DATA_DIR / "stacks").glob("*.csv"))
+        for stack_file in stack_files
     }
 
 

--- a/cli/assets/scripts/core.py
+++ b/cli/assets/scripts/core.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 from math import log
 from collections import defaultdict
+from typing import Dict
 
 # ============ CONFIGURATION ============
 DATA_DIR = Path(__file__).parent.parent / "data"
@@ -72,9 +73,21 @@ CSV_CONFIG = {
     }
 }
 
-STACK_CONFIG = {
-    "react-native": {"file": "stacks/react-native.csv"},
-}
+def _discover_stack_config() -> Dict[str, Dict[str, str]]:
+    """
+    Business Logic（为什么需要这个函数）:
+        CLI 安装产物需要暴露所有随包发布的 stack 指南，避免 Codex 用户安装后只能搜索 react-native。
+
+    Code Logic（这个函数做什么）:
+        扫描 data/stacks 目录下的 CSV 文件，以文件名 stem 作为 stack 名称，生成 search_stack 使用的配置字典。
+    """
+    return {
+        stack_file.stem: {"file": f"stacks/{stack_file.name}"}
+        for stack_file in sorted((DATA_DIR / "stacks").glob("*.csv"))
+    }
+
+
+STACK_CONFIG = _discover_stack_config()
 
 # Common columns for all stacks
 _STACK_COLS = {

--- a/cli/assets/scripts/search.py
+++ b/cli/assets/scripts/search.py
@@ -7,7 +7,7 @@ Usage: python search.py "<query>" [--domain <domain>] [--stack <stack>] [--max-r
        python search.py "<query>" --design-system --persist [-p "Project Name"] [--page "dashboard"]
 
 Domains: style, prompt, color, chart, landing, product, ux, typography
-Stacks: html-tailwind, react, nextjs
+Stacks: discovered from data/stacks/*.csv
 
 Persistence (Master + Overrides pattern):
   --persist    Save design system to design-system/MASTER.md
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UI Pro Max Search")
     parser.add_argument("query", help="Search query")
     parser.add_argument("--domain", "-d", choices=list(CSV_CONFIG.keys()), help="Search domain")
-    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help="Stack-specific search (html-tailwind, react, nextjs)")
+    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help=f"Stack-specific search ({', '.join(AVAILABLE_STACKS)})")
     parser.add_argument("--max-results", "-n", type=int, default=MAX_RESULTS, help="Max results (default: 3)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     # Design system generation

--- a/cli/assets/scripts/search.py
+++ b/cli/assets/scripts/search.py
@@ -55,11 +55,12 @@ def format_output(result):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UI Pro Max Search")
-    parser.add_argument("query", help="Search query")
+    parser.add_argument("query", nargs="?", help="Search query")
     parser.add_argument("--domain", "-d", choices=list(CSV_CONFIG.keys()), help="Search domain")
-    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help=f"Stack-specific search ({', '.join(AVAILABLE_STACKS)})")
+    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, metavar="STACK", help="Stack-specific search")
     parser.add_argument("--max-results", "-n", type=int, default=MAX_RESULTS, help="Max results (default: 3)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--list-stacks", action="store_true", help="List available stacks and exit")
     # Design system generation
     parser.add_argument("--design-system", "-ds", action="store_true", help="Generate complete design system recommendation")
     parser.add_argument("--project-name", "-p", type=str, default=None, help="Project name for design system output")
@@ -70,6 +71,13 @@ if __name__ == "__main__":
     parser.add_argument("--output-dir", "-o", type=str, default=None, help="Output directory for persisted files (default: current directory)")
 
     args = parser.parse_args()
+
+    if args.list_stacks:
+        print("\n".join(AVAILABLE_STACKS))
+        sys.exit(0)
+
+    if not args.query:
+        parser.error("the following arguments are required: query")
 
     # Design system takes priority
     if args.design_system:

--- a/cli/assets/templates/base/skill-content.md
+++ b/cli/assets/templates/base/skill-content.md
@@ -53,7 +53,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: Detect from the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
+- **Stack**: Choose the stack for the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -139,6 +139,12 @@ Get implementation-specific best practices for the detected stack:
 python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 ```
 
+To list available stack names:
+
+```bash
+python3 skills/ui-ux-pro-max/scripts/search.py --list-stacks
+```
+
 ---
 
 ## Search Reference
@@ -189,7 +195,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: detected from the current project
+- Stack: chosen for the current project
 
 ### Step 2: Generate Design System (REQUIRED)
 

--- a/cli/assets/templates/base/skill-content.md
+++ b/cli/assets/templates/base/skill-content.md
@@ -53,7 +53,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: Detect from the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -131,12 +131,12 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 | App interface a11y | `web` | `--domain web "accessibilityLabel touch safe-areas"` |
 | AI prompt / CSS keywords | `prompt` | `--domain prompt "minimalism"` |
 
-### Step 4: Stack Guidelines (React Native)
+### Step 4: Stack Guidelines
 
-Get React Native implementation-specific best practices:
+Get implementation-specific best practices for the detected stack:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 ```
 
 ---
@@ -162,7 +162,22 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 
 | Stack | Focus |
 |-------|-------|
-| `react-native` | Components, Navigation, Lists |
+| `angular` | Angular components, routing, forms, performance |
+| `astro` | Astro islands, content sites, partial hydration |
+| `flutter` | Flutter widgets, layout, navigation, performance |
+| `html-tailwind` | Static HTML and Tailwind CSS implementation |
+| `jetpack-compose` | Android Jetpack Compose UI patterns |
+| `laravel` | Laravel Blade, Livewire, and full-stack UI |
+| `nextjs` | Next.js routing, rendering, performance |
+| `nuxt-ui` | Nuxt UI components and theming |
+| `nuxtjs` | Nuxt.js architecture and rendering |
+| `react` | React components, hooks, rendering, performance |
+| `react-native` | React Native components, navigation, lists |
+| `shadcn` | shadcn/ui composition and theming |
+| `svelte` | Svelte components and reactivity |
+| `swiftui` | SwiftUI views, navigation, platform patterns |
+| `threejs` | Three.js scenes, rendering, interaction |
+| `vue` | Vue components, composition API, performance |
 
 ---
 
@@ -174,7 +189,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: React Native
+- Stack: detected from the current project
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -197,7 +212,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "search loading animation" --doma
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -225,7 +240,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system 
 - Use **multi-dimensional keywords** — combine product + industry + tone + density: `"entertainment social vibrant content-dense"` not just `"app"`
 - Try different keywords for the same need: `"playful neon"` → `"vibrant dark"` → `"content-first minimal"`
 - Use `--design-system` first for full recommendations, then `--domain` to deep-dive any dimension you're unsure about
-- Always add `--stack react-native` for implementation-specific guidance
+- Always add `--stack <stack>` for implementation-specific guidance when the project stack is known
 
 ### Common Sticking Points
 

--- a/cli/assets/templates/platforms/agent.json
+++ b/cli/assets/templates/platforms/agent.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/agent.json
+++ b/cli/assets/templates/platforms/agent.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/augment.json
+++ b/cli/assets/templates/platforms/augment.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/augment.json
+++ b/cli/assets/templates/platforms/augment.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/claude.json
+++ b/cli/assets/templates/platforms/claude.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 15 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, Astro, SwiftUI, React Native, Flutter, Nuxt, Nuxt UI, Tailwind, shadcn/ui, Jetpack Compose, Three.js, Angular, Laravel). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
   },
   "sections": {
     "quickReference": true
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/claude.json
+++ b/cli/assets/templates/platforms/claude.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, Astro, SwiftUI, React Native, Flutter, Nuxt, Nuxt UI, Tailwind, shadcn/ui, Jetpack Compose, Three.js, Angular, Laravel). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, multi-stack guidelines. Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
   },
   "sections": {
     "quickReference": true
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codebuddy.json
+++ b/cli/assets/templates/platforms/codebuddy.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codebuddy.json
+++ b/cli/assets/templates/platforms/codebuddy.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codex.json
+++ b/cli/assets/templates/platforms/codex.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/codex.json
+++ b/cli/assets/templates/platforms/codex.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/continue.json
+++ b/cli/assets/templates/platforms/continue.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/continue.json
+++ b/cli/assets/templates/platforms/continue.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/copilot.json
+++ b/cli/assets/templates/platforms/copilot.json
@@ -10,12 +10,12 @@
   "scriptPath": "prompts/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/copilot.json
+++ b/cli/assets/templates/platforms/copilot.json
@@ -10,12 +10,12 @@
   "scriptPath": "prompts/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/cursor.json
+++ b/cli/assets/templates/platforms/cursor.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/cursor.json
+++ b/cli/assets/templates/platforms/cursor.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/droid.json
+++ b/cli/assets/templates/platforms/droid.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 15 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
   },
   "sections": {
     "quickReference": false
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/droid.json
+++ b/cli/assets/templates/platforms/droid.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, multi-stack guidelines. Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
   },
   "sections": {
     "quickReference": false
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/gemini.json
+++ b/cli/assets/templates/platforms/gemini.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/gemini.json
+++ b/cli/assets/templates/platforms/gemini.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/kilocode.json
+++ b/cli/assets/templates/platforms/kilocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/kilocode.json
+++ b/cli/assets/templates/platforms/kilocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/kiro.json
+++ b/cli/assets/templates/platforms/kiro.json
@@ -10,12 +10,12 @@
   "scriptPath": "steering/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/kiro.json
+++ b/cli/assets/templates/platforms/kiro.json
@@ -10,12 +10,12 @@
   "scriptPath": "steering/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/opencode.json
+++ b/cli/assets/templates/platforms/opencode.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/opencode.json
+++ b/cli/assets/templates/platforms/opencode.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/qoder.json
+++ b/cli/assets/templates/platforms/qoder.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/qoder.json
+++ b/cli/assets/templates/platforms/qoder.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/roocode.json
+++ b/cli/assets/templates/platforms/roocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/roocode.json
+++ b/cli/assets/templates/platforms/roocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/cli/assets/templates/platforms/trae.json
+++ b/cli/assets/templates/platforms/trae.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/trae.json
+++ b/cli/assets/templates/platforms/trae.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/warp.json
+++ b/cli/assets/templates/platforms/warp.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/warp.json
+++ b/cli/assets/templates/platforms/warp.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/windsurf.json
+++ b/cli/assets/templates/platforms/windsurf.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/cli/assets/templates/platforms/windsurf.json
+++ b/cli/assets/templates/platforms/windsurf.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/scripts/core.py
+++ b/src/ui-ux-pro-max/scripts/core.py
@@ -81,9 +81,23 @@ def _discover_stack_config() -> Dict[str, Dict[str, str]]:
     Code Logic（这个函数做什么）:
         扫描 data/stacks 目录下的 CSV 文件，以文件名 stem 作为 stack 名称，生成 search_stack 使用的配置字典。
     """
+    stack_dir = DATA_DIR / "stacks"
+    if not stack_dir.is_dir():
+        raise RuntimeError(
+            f"Stack data directory not found: {stack_dir}. "
+            "Reinstall the skill or rebuild packaged assets."
+        )
+
+    stack_files = sorted(stack_dir.glob("*.csv"))
+    if not stack_files:
+        raise RuntimeError(
+            f"No stack CSV files found in: {stack_dir}. "
+            "Reinstall the skill or rebuild packaged assets."
+        )
+
     return {
         stack_file.stem: {"file": f"stacks/{stack_file.name}"}
-        for stack_file in sorted((DATA_DIR / "stacks").glob("*.csv"))
+        for stack_file in stack_files
     }
 
 

--- a/src/ui-ux-pro-max/scripts/core.py
+++ b/src/ui-ux-pro-max/scripts/core.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 from math import log
 from collections import defaultdict
+from typing import Dict
 
 # ============ CONFIGURATION ============
 DATA_DIR = Path(__file__).parent.parent / "data"
@@ -72,24 +73,21 @@ CSV_CONFIG = {
     }
 }
 
-STACK_CONFIG = {
-    "react":            {"file": "stacks/react.csv"},
-    "nextjs":           {"file": "stacks/nextjs.csv"},
-    "vue":              {"file": "stacks/vue.csv"},
-    "svelte":           {"file": "stacks/svelte.csv"},
-    "astro":            {"file": "stacks/astro.csv"},
-    "swiftui":          {"file": "stacks/swiftui.csv"},
-    "react-native":     {"file": "stacks/react-native.csv"},
-    "flutter":          {"file": "stacks/flutter.csv"},
-    "nuxtjs":           {"file": "stacks/nuxtjs.csv"},
-    "nuxt-ui":          {"file": "stacks/nuxt-ui.csv"},
-    "html-tailwind":    {"file": "stacks/html-tailwind.csv"},
-    "shadcn":           {"file": "stacks/shadcn.csv"},
-    "jetpack-compose":  {"file": "stacks/jetpack-compose.csv"},
-    "threejs":          {"file": "stacks/threejs.csv"},
-    "angular":          {"file": "stacks/angular.csv"},
-    "laravel":          {"file": "stacks/laravel.csv"},
-}
+def _discover_stack_config() -> Dict[str, Dict[str, str]]:
+    """
+    Business Logic（为什么需要这个函数）:
+        Skill 发布包中的 stack CSV 是可扩展数据源，用户需要所有随包发布的技术栈都自动可搜索，避免手写配置遗漏导致安装后只能查询部分 stack。
+
+    Code Logic（这个函数做什么）:
+        扫描 data/stacks 目录下的 CSV 文件，以文件名 stem 作为 stack 名称，生成 search_stack 使用的配置字典。
+    """
+    return {
+        stack_file.stem: {"file": f"stacks/{stack_file.name}"}
+        for stack_file in sorted((DATA_DIR / "stacks").glob("*.csv"))
+    }
+
+
+STACK_CONFIG = _discover_stack_config()
 
 # Common columns for all stacks
 _STACK_COLS = {

--- a/src/ui-ux-pro-max/scripts/search.py
+++ b/src/ui-ux-pro-max/scripts/search.py
@@ -55,11 +55,12 @@ def format_output(result):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UI Pro Max Search")
-    parser.add_argument("query", help="Search query")
+    parser.add_argument("query", nargs="?", help="Search query")
     parser.add_argument("--domain", "-d", choices=list(CSV_CONFIG.keys()), help="Search domain")
-    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help=f"Stack-specific search ({', '.join(AVAILABLE_STACKS)})")
+    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, metavar="STACK", help="Stack-specific search")
     parser.add_argument("--max-results", "-n", type=int, default=MAX_RESULTS, help="Max results (default: 3)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--list-stacks", action="store_true", help="List available stacks and exit")
     # Design system generation
     parser.add_argument("--design-system", "-ds", action="store_true", help="Generate complete design system recommendation")
     parser.add_argument("--project-name", "-p", type=str, default=None, help="Project name for design system output")
@@ -70,6 +71,13 @@ if __name__ == "__main__":
     parser.add_argument("--output-dir", "-o", type=str, default=None, help="Output directory for persisted files (default: current directory)")
 
     args = parser.parse_args()
+
+    if args.list_stacks:
+        print("\n".join(AVAILABLE_STACKS))
+        sys.exit(0)
+
+    if not args.query:
+        parser.error("the following arguments are required: query")
 
     # Design system takes priority
     if args.design_system:

--- a/src/ui-ux-pro-max/scripts/search.py
+++ b/src/ui-ux-pro-max/scripts/search.py
@@ -7,7 +7,7 @@ Usage: python search.py "<query>" [--domain <domain>] [--stack <stack>] [--max-r
        python search.py "<query>" --design-system --persist [-p "Project Name"] [--page "dashboard"]
 
 Domains: style, prompt, color, chart, landing, product, ux, typography, google-fonts
-Stacks: react, nextjs, vue, svelte, astro, swiftui, react-native, flutter, nuxtjs, nuxt-ui, html-tailwind, shadcn, jetpack-compose, threejs
+Stacks: discovered from data/stacks/*.csv
 
 Persistence (Master + Overrides pattern):
   --persist    Save design system to design-system/MASTER.md
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UI Pro Max Search")
     parser.add_argument("query", help="Search query")
     parser.add_argument("--domain", "-d", choices=list(CSV_CONFIG.keys()), help="Search domain")
-    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help=f"Stack-specific search. Available: {', '.join(AVAILABLE_STACKS)}")
+    parser.add_argument("--stack", "-s", choices=AVAILABLE_STACKS, help=f"Stack-specific search ({', '.join(AVAILABLE_STACKS)})")
     parser.add_argument("--max-results", "-n", type=int, default=MAX_RESULTS, help="Max results (default: 3)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     # Design system generation

--- a/src/ui-ux-pro-max/templates/base/skill-content.md
+++ b/src/ui-ux-pro-max/templates/base/skill-content.md
@@ -53,7 +53,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: Detect from the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
+- **Stack**: Choose the stack for the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -139,6 +139,12 @@ Get implementation-specific best practices for the detected stack:
 python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 ```
 
+To list available stack names:
+
+```bash
+python3 skills/ui-ux-pro-max/scripts/search.py --list-stacks
+```
+
 ---
 
 ## Search Reference
@@ -189,7 +195,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: detected from the current project
+- Stack: chosen for the current project
 
 ### Step 2: Generate Design System (REQUIRED)
 

--- a/src/ui-ux-pro-max/templates/base/skill-content.md
+++ b/src/ui-ux-pro-max/templates/base/skill-content.md
@@ -53,7 +53,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: Detect from the current project. If unclear, generate the design system first, then query the closest installed stack guidelines.
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -131,12 +131,12 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 | App interface a11y | `web` | `--domain web "accessibilityLabel touch safe-areas"` |
 | AI prompt / CSS keywords | `prompt` | `--domain prompt "minimalism"` |
 
-### Step 4: Stack Guidelines (React Native)
+### Step 4: Stack Guidelines
 
-Get React Native implementation-specific best practices:
+Get implementation-specific best practices for the detected stack:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <stack>
 ```
 
 ---
@@ -162,7 +162,22 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 
 | Stack | Focus |
 |-------|-------|
-| `react-native` | Components, Navigation, Lists |
+| `angular` | Angular components, routing, forms, performance |
+| `astro` | Astro islands, content sites, partial hydration |
+| `flutter` | Flutter widgets, layout, navigation, performance |
+| `html-tailwind` | Static HTML and Tailwind CSS implementation |
+| `jetpack-compose` | Android Jetpack Compose UI patterns |
+| `laravel` | Laravel Blade, Livewire, and full-stack UI |
+| `nextjs` | Next.js routing, rendering, performance |
+| `nuxt-ui` | Nuxt UI components and theming |
+| `nuxtjs` | Nuxt.js architecture and rendering |
+| `react` | React components, hooks, rendering, performance |
+| `react-native` | React Native components, navigation, lists |
+| `shadcn` | shadcn/ui composition and theming |
+| `svelte` | Svelte components and reactivity |
+| `swiftui` | SwiftUI views, navigation, platform patterns |
+| `threejs` | Three.js scenes, rendering, interaction |
+| `vue` | Vue components, composition API, performance |
 
 ---
 
@@ -174,7 +189,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: React Native
+- Stack: detected from the current project
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -197,7 +212,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "search loading animation" --doma
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -225,7 +240,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system 
 - Use **multi-dimensional keywords** — combine product + industry + tone + density: `"entertainment social vibrant content-dense"` not just `"app"`
 - Try different keywords for the same need: `"playful neon"` → `"vibrant dark"` → `"content-first minimal"`
 - Use `--design-system` first for full recommendations, then `--domain` to deep-dive any dimension you're unsure about
-- Always add `--stack react-native` for implementation-specific guidance
+- Always add `--stack <stack>` for implementation-specific guidance when the project stack is known
 
 ### Common Sticking Points
 

--- a/src/ui-ux-pro-max/templates/platforms/agent.json
+++ b/src/ui-ux-pro-max/templates/platforms/agent.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/augment.json
+++ b/src/ui-ux-pro-max/templates/platforms/augment.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/claude.json
+++ b/src/ui-ux-pro-max/templates/platforms/claude.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, Astro, SwiftUI, React Native, Flutter, Nuxt, Nuxt UI, Tailwind, shadcn/ui, Jetpack Compose, Three.js, Angular, Laravel). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, multi-stack guidelines. Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
   },
   "sections": {
     "quickReference": true
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/codebuddy.json
+++ b/src/ui-ux-pro-max/templates/platforms/codebuddy.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/codex.json
+++ b/src/ui-ux-pro-max/templates/platforms/codex.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/continue.json
+++ b/src/ui-ux-pro-max/templates/platforms/continue.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/copilot.json
+++ b/src/ui-ux-pro-max/templates/platforms/copilot.json
@@ -10,12 +10,12 @@
   "scriptPath": "prompts/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/cursor.json
+++ b/src/ui-ux-pro-max/templates/platforms/cursor.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/droid.json
+++ b/src/ui-ux-pro-max/templates/platforms/droid.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 16 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
+    "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, multi-stack guidelines. Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient."
   },
   "sections": {
     "quickReference": false
   },
   "title": "UI/UX Pro Max - Design Intelligence",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/gemini.json
+++ b/src/ui-ux-pro-max/templates/platforms/gemini.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/kilocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/kilocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/kiro.json
+++ b/src/ui-ux-pro-max/templates/platforms/kiro.json
@@ -10,12 +10,12 @@
   "scriptPath": "steering/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/opencode.json
+++ b/src/ui-ux-pro-max/templates/platforms/opencode.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/qoder.json
+++ b/src/ui-ux-pro-max/templates/platforms/qoder.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/roocode.json
+++ b/src/ui-ux-pro-max/templates/platforms/roocode.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Workflow"
 }

--- a/src/ui-ux-pro-max/templates/platforms/trae.json
+++ b/src/ui-ux-pro-max/templates/platforms/trae.json
@@ -16,6 +16,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/warp.json
+++ b/src/ui-ux-pro-max/templates/platforms/warp.json
@@ -13,6 +13,6 @@
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/src/ui-ux-pro-max/templates/platforms/windsurf.json
+++ b/src/ui-ux-pro-max/templates/platforms/windsurf.json
@@ -10,12 +10,12 @@
   "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
   "frontmatter": {
     "name": "ui-ux-pro-max",
-    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks."
+    "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks."
   },
   "sections": {
     "quickReference": false
   },
   "title": "ui-ux-pro-max",
-  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 16 technology stacks. Searchable database with priority-based recommendations.",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across bundled technology stacks. Searchable database with priority-based recommendations.",
   "skillOrWorkflow": "Skill"
 }

--- a/tests/test_stack_discovery.py
+++ b/tests/test_stack_discovery.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_core_module(core_path: Path, module_name: str) -> ModuleType:
+    """
+    Business Logic（为什么需要这个函数）:
+        回归测试需要分别验证源码 skill 与 CLI 打包 assets 中的 core.py，避免只修复其中一份导致发布产物继续缺失 stack。
+
+    Code Logic（这个函数做什么）:
+        接收 core.py 文件路径和临时模块名，使用 importlib 从指定路径加载模块并返回 ModuleType，供测试读取 AVAILABLE_STACKS 与 search_stack。
+    """
+    spec = importlib.util.spec_from_file_location(module_name, core_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {core_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class StackDiscoveryTest(unittest.TestCase):
+    """
+    Business Logic（为什么需要这个类）:
+        用户安装 Codex skill 后需要能查询所有随包发布的技术栈指南，而不是只能查询 react-native。
+
+    Code Logic（这个类做什么）:
+        对 src 与 cli/assets 两套发布入口执行同一组断言，确保 AVAILABLE_STACKS 覆盖 data/stacks/*.csv，且 React stack 可被实际搜索。
+    """
+
+    def assert_stack_files_are_registered(self, package_root: Path, core_path: Path, module_name: str) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            每新增一个 stack CSV 都应该自动成为可查询 stack，避免维护者忘记同步手写配置。
+
+        Code Logic（这个函数做什么）:
+            从 data/stacks 读取 CSV 文件 stem 集合，加载对应 core.py，断言 AVAILABLE_STACKS 与 CSV stem 完全一致。
+        """
+        expected_stacks = {
+            stack_file.stem
+            for stack_file in (package_root / "data" / "stacks").glob("*.csv")
+        }
+        core_module = load_core_module(core_path, module_name)
+
+        self.assertGreater(len(expected_stacks), 1)
+        self.assertEqual(expected_stacks, set(core_module.AVAILABLE_STACKS))
+
+    def test_cli_assets_register_all_packaged_stack_files(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            Codex 安装流程使用 CLI assets 生成 ~/.codex/skills/ui-ux-pro-max，因此 CLI assets 必须包含完整 stack 搜索能力。
+
+        Code Logic（这个函数做什么）:
+            验证 cli/assets/scripts/core.py 暴露的 AVAILABLE_STACKS 覆盖 cli/assets/data/stacks 下全部 CSV 文件。
+        """
+        package_root = REPO_ROOT / "cli" / "assets"
+        self.assert_stack_files_are_registered(
+            package_root,
+            package_root / "scripts" / "core.py",
+            "uipro_cli_assets_core",
+        )
+
+    def test_source_skill_registers_all_packaged_stack_files(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            源码 skill 目录同样可能被直接复制或打包发布，需要保持与 CLI assets 一致的 stack 覆盖。
+
+        Code Logic（这个函数做什么）:
+            验证 src/ui-ux-pro-max/scripts/core.py 暴露的 AVAILABLE_STACKS 覆盖 src/ui-ux-pro-max/data/stacks 下全部 CSV 文件。
+        """
+        package_root = REPO_ROOT / "src" / "ui-ux-pro-max"
+        self.assert_stack_files_are_registered(
+            package_root,
+            package_root / "scripts" / "core.py",
+            "uipro_source_core",
+        )
+
+    def test_cli_assets_can_search_react_stack(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            已安装的 Codex skill 需要支持 React 项目查询，不能在 argparse 或 stack config 阶段拒绝 react。
+
+        Code Logic（这个函数做什么）:
+            加载 CLI assets 的 core.py，调用 search_stack 查询 React 渲染建议，并断言结果来自 stacks/react.csv。
+        """
+        package_root = REPO_ROOT / "cli" / "assets"
+        core_module = load_core_module(
+            package_root / "scripts" / "core.py",
+            "uipro_cli_assets_core_search",
+        )
+
+        result = core_module.search_stack("memo rerender bundle", "react")
+
+        self.assertNotIn("error", result)
+        self.assertEqual("stacks/react.csv", result["file"])
+        self.assertGreater(result["count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stack_discovery.py
+++ b/tests/test_stack_discovery.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
+import sys
+import tempfile
 from types import ModuleType
 import unittest
 
@@ -43,14 +46,44 @@ class StackDiscoveryTest(unittest.TestCase):
         Code Logic（这个函数做什么）:
             从 data/stacks 读取 CSV 文件 stem 集合，加载对应 core.py，断言 AVAILABLE_STACKS 与 CSV stem 完全一致。
         """
+        stack_dir = package_root / "data" / "stacks"
+        self.assertTrue(
+            stack_dir.is_dir(),
+            f"Expected stack data directory to exist: {stack_dir}",
+        )
         expected_stacks = {
             stack_file.stem
-            for stack_file in (package_root / "data" / "stacks").glob("*.csv")
+            for stack_file in stack_dir.glob("*.csv")
         }
         core_module = load_core_module(core_path, module_name)
 
         self.assertGreater(len(expected_stacks), 1)
         self.assertEqual(expected_stacks, set(core_module.AVAILABLE_STACKS))
+
+    def test_core_fails_fast_when_stack_directory_is_missing(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            发布包如果缺失 data/stacks，用户需要看到明确的打包错误，而不是得到空 stack 列表后再遇到难懂的 unknown stack。
+
+        Code Logic（这个函数做什么）:
+            将两套 core.py 分别复制到缺少 data/stacks 的临时目录中导入，断言导入阶段抛出包含 Stack data directory not found 的 RuntimeError。
+        """
+        core_paths = [
+            REPO_ROOT / "src" / "ui-ux-pro-max" / "scripts" / "core.py",
+            REPO_ROOT / "cli" / "assets" / "scripts" / "core.py",
+        ]
+
+        for index, core_path in enumerate(core_paths):
+            with self.subTest(core_path=core_path):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    temp_root = Path(temp_dir) / "package"
+                    temp_scripts = temp_root / "scripts"
+                    temp_scripts.mkdir(parents=True)
+                    temp_core = temp_scripts / "core.py"
+                    temp_core.write_text(core_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+                    with self.assertRaisesRegex(RuntimeError, "Stack data directory not found"):
+                        load_core_module(temp_core, f"uipro_missing_stack_core_{index}")
 
     def test_cli_assets_register_all_packaged_stack_files(self) -> None:
         """
@@ -101,6 +134,49 @@ class StackDiscoveryTest(unittest.TestCase):
         self.assertNotIn("error", result)
         self.assertEqual("stacks/react.csv", result["file"])
         self.assertGreater(result["count"], 0)
+
+    def test_cli_assets_lists_stacks_without_query(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            用户需要一种明确方式查看可用 stack，同时不应该为了查看列表而被迫提供无意义 query。
+
+        Code Logic（这个函数做什么）:
+            执行 CLI assets 的 search.py --list-stacks，断言命令成功且输出包含 react 与 threejs。
+        """
+        search_script = REPO_ROOT / "cli" / "assets" / "scripts" / "search.py"
+
+        result = subprocess.run(
+            [sys.executable, str(search_script), "--list-stacks"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertIn("react", result.stdout.splitlines())
+        self.assertIn("threejs", result.stdout.splitlines())
+
+    def test_cli_assets_help_keeps_stack_option_concise(self) -> None:
+        """
+        Business Logic（为什么需要这个函数）:
+            stack 数量会随 CSV 增长，--help 不应把完整列表重复塞进 usage 与选项说明，避免 CLI 帮助持续膨胀。
+
+        Code Logic（这个函数做什么）:
+            执行 search.py --help，断言 stack 参数使用简短 metavar，并提供 --list-stacks 作为查看完整列表的入口。
+        """
+        search_script = REPO_ROOT / "cli" / "assets" / "scripts" / "search.py"
+
+        result = subprocess.run(
+            [sys.executable, str(search_script), "--help"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertIn("--stack STACK", result.stdout)
+        self.assertIn("--list-stacks", result.stdout)
+        self.assertNotIn("--stack {angular,astro", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Discover stack search configs from `data/stacks/*.csv` instead of maintaining a hand-written list
- Fix CLI packaged assets so installed Codex skills can search React, Next.js, Vue, Three.js, and other bundled stack CSVs
- Update generated skill guidance and CLI platform metadata from 15 to 16 stacks
- Add regression coverage for source and CLI packaged stack discovery

## Verification
- `python3 -m py_compile src/ui-ux-pro-max/scripts/core.py src/ui-ux-pro-max/scripts/search.py src/ui-ux-pro-max/scripts/design_system.py cli/assets/scripts/core.py cli/assets/scripts/search.py cli/assets/scripts/design_system.py tests/test_stack_discovery.py`
- `python3 -m unittest tests/test_stack_discovery.py`
- `python3 cli/assets/scripts/search.py "memo rerender bundle" --stack react`
- `diff -qr src/ui-ux-pro-max/templates/platforms cli/assets/templates/platforms`
- `npm run build` from `cli/`
- Temporary `node cli/dist/index.js init --ai codex` install smoke test, followed by generated skill `--stack react` search
