### PR TITLE
feat: release workflow with SHA256 checksums + fix Python CI

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,34 +1,25 @@
-name: Python Package using Conda
+name: Python Tests
 
-on: [push]
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/ui-ux-pro-max/scripts/**'
+  pull_request:
+    paths:
+      - 'src/ui-ux-pro-max/scripts/**'
 
 jobs:
-  build-linux:
+  test:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name base
-    - name: Lint with flake8
-      run: |
-        conda install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        conda install pytest
-        pytest
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run tests
+        run: python -m pytest src/ui-ux-pro-max/scripts/tests/ -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write  # needed to create GitHub releases and upload assets
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ── Build CLI ────────────────────────────────────────────────────────────
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install CLI dependencies
+        working-directory: cli
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        working-directory: cli
+        run: bun run build
+
+      # ── Package release ZIP ──────────────────────────────────────────────────
+      - name: Create release ZIP
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          ZIP_NAME="ui-ux-pro-max-${TAG}.zip"
+
+          # Bundle: repo contents minus git internals, node_modules, and test artefacts
+          zip -r "${ZIP_NAME}" . \
+            --exclude "*.git*" \
+            --exclude "*/node_modules/*" \
+            --exclude "*/dist/*" \
+            --exclude "*/__pycache__/*" \
+            --exclude "*.pyc" \
+            --exclude "*/bun.lock"
+
+          echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
+
+      # ── Compute checksums ────────────────────────────────────────────────────
+      - name: Generate SHA256 checksum
+        run: |
+          sha256sum "${ZIP_NAME}" > checksums.sha256
+          echo "--- Checksum file contents ---"
+          cat checksums.sha256
+
+      # ── Create GitHub Release ────────────────────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            ${{ env.ZIP_NAME }}
+            checksums.sha256


### PR DESCRIPTION
## Summary
- **`release.yml`** — New workflow triggered on `v*.*.*` tags: builds the CLI with Bun, packages a release ZIP, computes a `checksums.sha256` file with `sha256sum`, and uploads both as GitHub Release assets. Completes the integrity story end-to-end (the CLI already verifies magic bytes and logs SHA256 on download).
- **`python-package-conda.yml`** — Replaced broken Conda workflow (depended on `environment.yml` that doesn't exist) with a clean `pytest` runner scoped to `scripts/**` changes on `main` and PRs.

## Test plan
- [ ] Push a `v2.5.1` tag → confirm release is created with a `.zip` and `checksums.sha256` asset
- [ ] `sha256sum -c checksums.sha256` against the downloaded ZIP should print `OK`
- [ ] Open a PR touching `src/ui-ux-pro-max/scripts/` → Python CI job runs and passes