### PR TITLE
fix: correct project name in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Antigravity Kit is an AI-powered design intelligence toolkit providing searchable databases of UI styles, color palettes, font pairings, chart types, and UX guidelines. It works as a skill/workflow for AI coding assistants (Claude Code, Windsurf, Cursor, etc.).
+UI UX Pro Max is an AI-powered design intelligence toolkit providing searchable databases of UI styles, color palettes, font pairings, chart types, and UX guidelines. It works as a skill/workflow for AI coding assistants (Claude Code, Windsurf, Cursor, etc.).
 
 ## Search Command
 


### PR DESCRIPTION
## Summary

- The `Project Overview` section in `CLAUDE.md` referred to the project as **"Antigravity Kit"** — a stale name from an earlier version.
- Updated to the correct name: **UI UX Pro Max**.

## Test plan

- [ ] Verify `CLAUDE.md` Project Overview reads "UI UX Pro Max is an AI-powered design intelligence toolkit..."
- [ ] No functional code changed — docs-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)