### PR TITLE
docs(skill): make SKILL.md stack-neutral (currently hardcoded to React Native)

### DIFF
--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -356,7 +356,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: Match the project's framework. The engine ships guidance for many stacks (see [Available Stacks](#available-stacks) below) — pass the matching `--stack` (e.g. `nextjs`, `react`, `shadcn`, `vue`, `svelte`, `astro`, `swiftui`, `flutter`, `react-native`).
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -436,12 +436,14 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 | App interface a11y | `web` | `--domain web "accessibilityLabel touch safe-areas"` |
 | AI prompt / CSS keywords | `prompt` | `--domain prompt "minimalism"` |
 
-### Step 4: Stack Guidelines (React Native)
+### Step 4: Stack Guidelines (match your framework)
 
-Get React Native implementation-specific best practices:
+Get implementation-specific best practices for the stack you're building in.
+Pass the `--stack` that matches the project's framework:
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack <your-stack>
+# e.g. --stack nextjs | react | shadcn | vue | svelte | astro | swiftui | flutter | react-native
 ```
 
 ---
@@ -466,9 +468,26 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 
 ### Available Stacks
 
+Run `ls <skill>/data/stacks/` to see the live set. Shipped stacks:
+
 | Stack | Focus |
 |-------|-------|
+| `react` | Components, hooks, render performance |
+| `nextjs` | App Router, RSC, Server Actions, rendering |
+| `vue` | Components, Composition API, reactivity |
+| `nuxtjs` | Nuxt app patterns, SSR data fetching |
+| `nuxt-ui` | Nuxt UI component patterns |
+| `svelte` | Components, stores, transitions |
+| `astro` | Islands, content, partial hydration |
+| `shadcn` | shadcn/ui primitives, composition |
+| `html-tailwind` | Tailwind utility patterns |
+| `angular` | Components, signals, services |
+| `laravel` | Blade / server-rendered UI patterns |
+| `swiftui` | Views, state, navigation (iOS/macOS) |
+| `flutter` | Widgets, state, navigation |
+| `jetpack-compose` | Composables, state, navigation (Android) |
 | `react-native` | Components, Navigation, Lists |
+| `threejs` | 3D scenes, materials, performance |
 
 ---
 
@@ -480,7 +499,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: React Native
+- Stack: Next.js (a homepage is a web surface; use a web `--stack`)
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -503,7 +522,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "search loading animation" --doma
 ### Step 4: Stack Guidelines
 
 ```bash
-python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack react-native
+python3 skills/ui-ux-pro-max/scripts/search.py "list performance navigation" --stack nextjs
 ```
 
 **Then:** Synthesize design system + detailed searches and implement the design.
@@ -531,7 +550,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system 
 - Use **multi-dimensional keywords** — combine product + industry + tone + density: `"entertainment social vibrant content-dense"` not just `"app"`
 - Try different keywords for the same need: `"playful neon"` → `"vibrant dark"` → `"content-first minimal"`
 - Use `--design-system` first for full recommendations, then `--domain` to deep-dive any dimension you're unsure about
-- Always add `--stack react-native` for implementation-specific guidance
+- Add the `--stack` that matches the project's framework for implementation-specific guidance
 
 ### Common Sticking Points
 


### PR DESCRIPTION
## Problem

The skill **body** in `.claude/skills/ui-ux-pro-max/SKILL.md` is hardcoded to React Native, which contradicts the rest of the package:

- **Step 1 → Stack:** `React Native (this project's only tech stack)`
- **Available Stacks** table lists a single row: `react-native`
- Step 4, the example workflow, and the Tips section all hardcode `--stack react-native`

But the skill actually ships **16 stack datasets** in [`data/stacks/`](../tree/main/.claude/skills/ui-ux-pro-max/data/stacks) (`react`, `nextjs`, `vue`, `nuxtjs`, `nuxt-ui`, `svelte`, `astro`, `shadcn`, `html-tailwind`, `angular`, `laravel`, `swiftui`, `flutter`, `jetpack-compose`, `react-native`, `threejs`), and both the SKILL.md **frontmatter** description and `plugin.json` advertise a multi-stack ("web and mobile", 15 stacks) tool.

Net effect: `--stack nextjs` (etc.) have always worked, but the prose tells the agent this is a React-Native-only skill — so an agent reading the body steers every project, including web apps, toward React Native / `StyleSheet` guidance. The phrase *"this project's only tech stack"* also doesn't make sense for a cross-project design skill.

## Fix

Make the body framework-agnostic (no behavior/script changes — docs only, single file):

| Spot | Before | After |
|---|---|---|
| Step 1 "Stack" bullet | `React Native (this project's only tech stack)` | "Match the project's framework" + example `--stack` values |
| Step 4 heading + cmd | `(React Native)`, `--stack react-native` | "match your framework", `--stack <your-stack>` |
| Available Stacks table | 1 row | all 16 shipped stacks (+ `ls data/stacks/` hint) |
| Example workflow (a *homepage*) | `Stack: React Native` | `Next.js` (a homepage is a web surface) |
| Tips line | `Always add --stack react-native` | "add the `--stack` that matches the project's framework" |

Diff is +26/−7 in one file. The legitimate React Native references (the `react-native` stack row, the `react-native-vector-icons` example in the no-emoji rule) are kept.