### PR TITLE
Add Pi Coding Agent (pi.dev) as a first-class supported AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ uipro init --ai droid       # Droid (Factory)
 uipro init --ai kilocode    # KiloCode
 uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
+uipro init --ai pi          # Pi Coding Agent (https://pi.dev)
 uipro init --ai all         # All assistants
 ```
 

--- a/cli/assets/templates/platforms/pi.json
+++ b/cli/assets/templates/platforms/pi.json
@@ -1,0 +1,21 @@
+{
+  "platform": "pi",
+  "displayName": "Pi Coding Agent",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".pi",
+    "skillPath": "agent/skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "agent/skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+  },
+  "sections": {
+    "quickReference": true
+  },
+  "title": "UI/UX Pro Max - Design Intelligence",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'all';
+export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'pi' | 'all';
 
 export type InstallType = 'full' | 'reference';
 
@@ -41,7 +41,7 @@ export interface PlatformConfig {
   skillOrWorkflow: string;
 }
 
-export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'all'];
+export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'pi', 'all'];
 
 // Legacy folder mapping for backward compatibility with ZIP-based installs.
 // Note: .shared is included for platforms that used ZIP installs. Post-ZIP platforms
@@ -65,4 +65,10 @@ export const AI_FOLDERS: Record<Exclude<AIType, 'all'>, string[]> = {
   kilocode: ['.kilocode', '.shared'],
   warp: ['.warp', '.shared'],
   augment: ['.augment', '.shared'],
+  // Pi installs into ~/.pi/agent/skills/<name>/SKILL.md. The
+  // `.pi` folder is the conventional root for both project-local
+  // (.pi/skills/) and user-global (~/.pi/agent/skills/) skill discovery.
+  // The cli writes the skill under agent/skills/ to match the user
+  // global location; project-local discovery also picks this up.
+  pi: ['.pi'],
 };

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { AIType } from '../types/index.js';
 
 interface DetectionResult {
@@ -64,6 +65,9 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.augment'))) {
     detected.push('augment');
   }
+  if (existsSync(join(cwd, '.pi')) || existsSync(join(homedir(), '.pi'))) {
+    detected.push('pi');
+  }
 
   // Suggest based on what's detected
   let suggested: AIType | null = null;
@@ -114,6 +118,8 @@ export function getAITypeDescription(aiType: AIType): string {
       return 'Warp (.warp/skills/)';
     case 'augment':
       return 'Augment (.augment/skills/)';
+    case 'pi':
+      return 'Pi Coding Agent (.pi/agent/skills/)';
     case 'all':
       return 'All AI assistants';
   }

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -46,6 +46,7 @@ const AI_TO_PLATFORM: Record<string, string> = {
   kilocode: 'kilocode',
   warp: 'warp',
   augment: 'augment',
+  pi: 'pi',
 };
 
 async function exists(path: string): Promise<boolean> {

--- a/skill.json
+++ b/skill.json
@@ -35,7 +35,8 @@
     "droid",
     "warp",
     "augment",
-    "antigravity"
+    "antigravity",
+    "pi"
   ],
   "install": "npx uipro-cli init --ai {{platform}}"
 }

--- a/src/ui-ux-pro-max/templates/platforms/pi.json
+++ b/src/ui-ux-pro-max/templates/platforms/pi.json
@@ -1,0 +1,21 @@
+{
+  "platform": "pi",
+  "displayName": "Pi Coding Agent",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".pi",
+    "skillPath": "agent/skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "agent/skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app, .html, .tsx, .vue, .svelte. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient. Integrations: shadcn/ui MCP for component search and examples."
+  },
+  "sections": {
+    "quickReference": true
+  },
+  "title": "UI/UX Pro Max - Design Intelligence",
+  "description": "Comprehensive design guide for web and mobile applications. Contains 67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 13 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}


### PR DESCRIPTION
## Summary

Adds `uipro init --ai pi` support. Pi Coding Agent users can install the UI/UX Pro Max skill with the standard one-command install instead of a manual file-copy workaround.

## Why

I was setting up UI/UX Pro Max for a Pi session. Pi is not in the supported list of `uipro init --ai` assistants (claude, cursor, codex, etc.). I worked around it by running `uipro init --ai claude --offline` and copying the result to `~/.pi/agent/skills/ui-ux-pro-max/`. That works because the Agent Skills standard (agentskills.io) is shared across pi, Claude Code, Codex, and Cursor — same `SKILL.md` + YAML frontmatter, same directory layout. But the workaround is janky: the user is depending on skill-format convergence rather than the package declaring support.

The fix is to add a proper `pi.json` to the templates and register `pi` in the type system so future installs are first-class.

## Changes

- **New** `src/ui-ux-pro-max/templates/platforms/pi.json` (and mirrored `cli/assets/templates/platforms/pi.json`) — install config matching pi's skill discovery rules.
- **Modified** `cli/src/types/index.ts` — added `pi` to the `AIType` union, `AI_TYPES` array, and `AI_FOLDERS` (pi: ['.pi']).
- **Modified** `cli/src/utils/template.ts` — added `pi: 'pi'` to `AI_TO_PLATFORM`.
- **Modified** `cli/src/utils/detect.ts` — auto-detect `pi` from `.pi/` (project-local) or `~/.pi/` (user-global) and added Pi case to `getAITypeDescription`.
- **Modified** `skill.json` — added `pi` to the platforms list.
- **Modified** `README.md` — added `uipro init --ai pi` to the install list.

## Pi install layout

Pi's skill discovery (per the Agent Skills spec) reads from:
- Global: `~/.pi/agent/skills/<name>/SKILL.md`
- Project-local: `.pi/skills/<name>/SKILL.md`

The platform config sets:
```json
{
  "folderStructure": {
    "root": ".pi",
    "skillPath": "agent/skills/ui-ux-pro-max",
    "filename": "SKILL.md"
  },
  "scriptPath": "agent/skills/ui-ux-pro-max/scripts/search.py"
}
```

User-global install writes to `~/.pi/agent/skills/ui-ux-pro-max/` (which `uipro init --global` already handles via the `--global` flag on the existing CLI). Project-local installs write to `<project>/.pi/agent/skills/ui-ux-pro-max/`. Both are picked up by pi on startup.

## Verified locally

- `bun build src/index.ts --outdir dist --target node` succeeds.
- `uipro init --ai pi --offline` runs and writes the expected files to `.pi/agent/skills/ui-ux-pro-max/`.
- `python3 .pi/agent/skills/ui-ux-pro-max/scripts/search.py "fintech dashboard" --design-system -p "Test"` returns a complete design system spec (pattern + style + colors + typography + effects).
- `uipro init --help` lists `pi` alongside the other supported types.

## Compatibility

- No breaking changes. Pi is purely additive to the AI type union.
- Existing installs (claude, codex, cursor, etc.) are unaffected.
- The `AI_TO_PLATFORM` mapping follows the existing convention (key and value are the same for most platforms; `antigravity: 'agent'` is the precedent for sharing a config file across types).

## Test plan

I tested in a temp directory. For upstream acceptance testing:

```bash
mkdir -p /tmp/test && cd /tmp/test
uipro init --ai pi --offline
python3 .pi/agent/skills/ui-ux-pro-max/scripts/search.py 'glassmorphism' --domain style
python3 .pi/agent/skills/ui-ux-pro-max/scripts/search.py 'fintech dashboard' --design-system -p 'Test'
```

Both should succeed. The `scripts/` directory ships the BM25 search engine and design-system generator that work without any external API calls.

## Related

- Pi Coding Agent: https://github.com/mariozechner/pi-coding-agent
- Agent Skills spec: https://agentskills.io/specification
- pi.dev/packages: https://pi.dev/packages