### PR TITLE
fix: bump skill.json version to 2.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "UI/UX design intelligence skill with 67 styles, 161 palettes, 57 font pairings, 25 charts, and 15 stack guidelines",
-    "version": "2.5.0"
+    "version": "2.6.2"
   },
   "plugins": [
     {
       "name": "ui-ux-pro-max",
       "source": "./",
       "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and Jetpack Compose.",
-      "version": "2.5.0",
+      "version": "2.6.2",
       "author": {
         "name": "nextlevelbuilder"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-ux-pro-max",
   "description": "UI/UX design intelligence. 67 styles, 161 palettes, 57 font pairings, 25 charts, 15 stacks (React, Next.js, Vue, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Nuxt, Jetpack Compose). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, mobile app. Elements: button, modal, navbar, sidebar, card, table, form, chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, flat design. Topics: color palette, accessibility, animation, layout, typography, font pairing, spacing, hover, shadow, gradient.",
-  "version": "2.5.0",
+  "version": "2.6.2",
   "author": {
     "name": "nextlevelbuilder"
   },

--- a/skill.json
+++ b/skill.json
@@ -2,7 +2,7 @@
   "name": "ui-ux-pro-max",
   "displayName": "UI/UX Pro Max",
   "description": "AI-powered design intelligence with 67 UI styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 15+ tech stacks.",
-  "version": "2.5.0",
+  "version": "2.6.2",
   "author": "NextLevelBuilder",
   "license": "MIT",
   "homepage": "https://uupm.cc",


### PR DESCRIPTION
## Summary

- Bumps `skill.json` version from `2.5.0` to `2.6.2` to match the latest GitHub release

## Why

The latest release tag is `v2.6.2` (released 2026-06-22), but `skill.json` still declares version `2.5.0`. This causes `claude plugins update` to report "already at latest version (2.5.0)" even though a newer version exists — the Claude Code plugin system reads `skill.json` to determine the available version.

Related release: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/releases/tag/v2.6.2