### PR TITLE
fix: replace colon with hyphen in skill names (validation error)

### DIFF
--- a/.claude/skills/banner-design/SKILL.md
+++ b/.claude/skills/banner-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:banner-design
+name: ckm-banner-design
 description: "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills."
 argument-hint: "[platform] [style] [dimensions]"
 license: MIT

--- a/.claude/skills/brand/SKILL.md
+++ b/.claude/skills/brand/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:brand
+name: ckm-brand
 description: Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.
 argument-hint: "[update|review|create] [args]"
 metadata:

--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:design-system
+name: ckm-design-system
 description: Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.
 argument-hint: "[component or token]"
 license: MIT

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:design
+name: ckm-design
 description: "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads."
 argument-hint: "[design-type] [context]"
 license: MIT

--- a/.claude/skills/slides/SKILL.md
+++ b/.claude/skills/slides/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:slides
+name: ckm-slides
 description: Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.
 argument-hint: "[topic] [slide-count]"
 metadata:

--- a/.claude/skills/ui-styling/SKILL.md
+++ b/.claude/skills/ui-styling/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm:ui-styling
+name: ckm-ui-styling
 description: Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.
 argument-hint: "[component or layout]"
 license: MIT


### PR DESCRIPTION
## Problem

All six `ckm:`-prefixed skill names use a colon character which violates the [Agent Skills spec](https://github.com/agent-skills-spec) name validation:

```
name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)
```

This causes a "Skill conflicts" warning on every session start for users of tools that validate skill names (e.g. pi, Claude Code).

## Fix

Replace `ckm:` → `ckm-` in all six SKILL.md frontmatter name fields.

## Affected files

- `.claude/skills/banner-design/SKILL.md`
- `.claude/skills/brand/SKILL.md`
- `.claude/skills/design/SKILL.md`
- `.claude/skills/design-system/SKILL.md`
- `.claude/skills/slides/SKILL.md`
- `.claude/skills/ui-styling/SKILL.md`