### PR TITLE
feat(release): publish uipro-cli to npm on release (#353)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx --yes \
             -p semantic-release \
             -p @semantic-release/commit-analyzer \
             -p @semantic-release/release-notes-generator \
+            -p @semantic-release/npm \
             -p @semantic-release/github \
             -p conventional-changelog-conventionalcommits \
             semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,6 +22,12 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "cli"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "successComment": false,


### PR DESCRIPTION
## What & why

`uipro init` / `uipro update` users still receive **2.2.3-era** assets even though the repo has advanced to **v2.7.0** (issue #353). Root cause: the `Release` workflow runs semantic-release with only the **github** plugin, so it creates GitHub releases/tags but **never publishes the `uipro-cli` package to npm**.

| Source | Version |
|---|---|
| npm `uipro-cli` (what users install) | **2.2.3** |
| newest git tag | **v2.7.0** |

## Change

Add `@semantic-release/npm` to the release pipeline so every release also publishes the CLI package at the tagged version:

- **`.releaserc.json`** — add `@semantic-release/npm` with `pkgRoot: "cli"` (between `release-notes-generator` and `github`).
- **`.github/workflows/release.yml`** — add `-p @semantic-release/npm` to the `npx` invocation and `NPM_TOKEN` to the step env.

The package's existing `prepublishOnly` (`sync:assets && typecheck && build`) runs on publish, so the tarball always ships current, in-sync assets.

## Required maintainer setup

⚠️ **Add a repo secret `NPM_TOKEN`** — an npm **automation** token with publish rights to `uipro-cli`. Without it, the npm step fails at `verifyConditions`.

After this merges and a release runs, npm will receive the current version (e.g. `2.7.x`/`2.8.0`) instead of `2.2.3`.

## Scope

This is the **npm-publish slice** of the release lane mrgoonie outlined (synced assets ✅ #355 · working release workflow ✅ on main · **npm publish/tag → this PR** · safe updater command → #326). Intentionally leaves #353 open until the full distribution path lands.

## Notes / optional follow-up

- semantic-release sets the published version from the git tag; it does not commit the bump back to `cli/package.json` (stays cosmetic at 2.5.0). If you want the repo's `package.json`/`skill.json` version to track the published version, add `@semantic-release/git` in a follow-up.
- `id-token: write` is already granted, so npm provenance (`NPM_CONFIG_PROVENANCE: true`) can be enabled later if desired.
