### PR TITLE
fix(plugin): register all 7 skills in the Claude Code plugin (#360, #266)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,5 +7,5 @@
   },
   "license": "MIT",
   "keywords": ["ui", "ux", "design", "styles", "typography", "color-palette", "accessibility", "charts", "components"],
-  "skills": ["./.claude/skills/ui-ux-pro-max"]
+  "skills": "./.claude/skills/"
 }

--- a/.claude/skills/banner-design/SKILL.md
+++ b/.claude/skills/banner-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-banner-design
+name: banner-design
 description: "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills."
 argument-hint: "[platform] [style] [dimensions]"
 license: MIT

--- a/.claude/skills/brand/SKILL.md
+++ b/.claude/skills/brand/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-brand
+name: brand
 description: Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.
 argument-hint: "[update|review|create] [args]"
 metadata:

--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-design-system
+name: design-system
 description: Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.
 argument-hint: "[component or token]"
 license: MIT

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-design
+name: design
 description: "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads."
 argument-hint: "[design-type] [context]"
 license: MIT

--- a/.claude/skills/slides/SKILL.md
+++ b/.claude/skills/slides/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-slides
+name: slides
 description: Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.
 argument-hint: "[topic] [slide-count]"
 metadata:

--- a/.claude/skills/ui-styling/SKILL.md
+++ b/.claude/skills/ui-styling/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ckm-ui-styling
+name: ui-styling
 description: Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.
 argument-hint: "[component or layout]"
 license: MIT


### PR DESCRIPTION
## What & why

Claude Code plugin users (install via marketplace) see only **1 of 7** skills — sometimes 0. Two independent root causes in the repo's plugin metadata:

### 1. `plugin.json` skills field (#360)
`.claude-plugin/plugin.json` declared:
```json
"skills": ["./.claude/skills/ui-ux-pro-max"]
```
An **array pointing at one subfolder**. With a marketplace-root source, listing a specific path **replaces** the default skills scan, so only `ui-ux-pro-max` is eligible and the other 6 never load. Fixed by pointing at the **parent directory** so the loader scans all `<name>/SKILL.md` subfolders:
```json
"skills": "./.claude/skills/"
```

### 2. Sub-skill `name` ≠ directory (#266)
The 6 sub-skill `SKILL.md` `name:` fields still carried a `ckm-` prefix after #383 only swapped the invalid colon — e.g. `name: ckm-brand` in directory `brand`. Loaders that require `name == directory` reject these. Stripped the prefix in all 6 so each name equals its folder.

## Result

All 7 skill folders now satisfy `name == directory` and are discoverable under the parent path:

| folder | name |
|---|---|
| ui-ux-pro-max | ui-ux-pro-max |
| design · design-system · banner-design · brand · slides · ui-styling | (match) |

## Scope / notes

- 7-line diff, no code logic touched.
- `ckm-` appears **only** in those 6 `name:` lines repo-wide — nothing else references them.
- The stale `/ckm:brand`-style slash-command strings in `design/SKILL.md` docs are a **separate** pre-existing concern (command invocation, not the `name` field) and out of scope here.
- This is the **plugin/marketplace** channel. The parallel npm-CLI symptom (`uipro init` installs only 1 of 7) is #362, handled in a separate CLI PR.

Closes #360
Closes #266
