### PR TITLE
fix(cli): replace stale data/scripts pointer files on install (#237)

### DIFF
--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -1,4 +1,4 @@
-import { readFile, mkdir, writeFile, cp, access, readdir } from 'node:fs/promises';
+import { readFile, mkdir, writeFile, cp, access, readdir, lstat, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -157,6 +157,23 @@ export async function renderSkillFile(config: PlatformConfig, isGlobal = false):
 }
 
 /**
+ * Replace a pre-existing non-directory at `path` so a real directory can be
+ * created there. Older CLI installs (and Windows checkouts of the repo's
+ * symlinked data/scripts) can leave plain "pointer" files at these paths;
+ * mkdir then throws EEXIST and the install silently leaves stale files.
+ */
+async function ensureCleanDir(path: string): Promise<void> {
+  try {
+    const stat = await lstat(path);
+    if (!stat.isDirectory()) {
+      await rm(path, { recursive: true, force: true });
+    }
+  } catch {
+    // Nothing exists at the path yet — mkdir will create it.
+  }
+}
+
+/**
  * Copy data and scripts to target directory
  */
 async function copyDataAndScripts(targetSkillDir: string): Promise<void> {
@@ -168,12 +185,14 @@ async function copyDataAndScripts(targetSkillDir: string): Promise<void> {
 
   // Copy data
   if (await exists(dataSource)) {
+    await ensureCleanDir(dataTarget);
     await mkdir(dataTarget, { recursive: true });
     await cp(dataSource, dataTarget, { recursive: true });
   }
 
   // Copy scripts
   if (await exists(scriptsSource)) {
+    await ensureCleanDir(scriptsTarget);
     await mkdir(scriptsTarget, { recursive: true });
     await cp(scriptsSource, scriptsTarget, { recursive: true });
   }


### PR DESCRIPTION
## What & why

On Windows, `uipro init` (especially `--ai all`) can leave a platform — e.g. **codex** — with broken `data`/`scripts` **pointer files** instead of real directories (#237).

**Root cause:** if `<skill>/data` or `<skill>/scripts` already exists as a *plain file* (left by an older CLI, or by a git checkout that materialized the repo's symlinked `data`/`scripts` as text "pointer" files), `copyDataAndScripts` calls `mkdir(target, { recursive: true })` on that path, which throws **`EEXIST`**. Under `--ai all`, `generateAllPlatformFiles` swallows the per-platform error (`template.ts:238`), so that platform is left with the stale pointer files and no real directories — exactly the reported symptom. A clean install is unaffected, which is why a fresh temp-dir install "works".

## Fix

Add `ensureCleanDir()`: before `mkdir`, `lstat` the target and remove it **only if it isn't already a directory**. Existing real directories are preserved, so re-installs are unaffected. Applied before both the `data` and `scripts` copies (the same path runs for all 18 platforms, so no platform regresses).

```ts
async function ensureCleanDir(path: string): Promise<void> {
  try {
    const stat = await lstat(path);
    if (!stat.isDirectory()) await rm(path, { recursive: true, force: true });
  } catch { /* nothing there yet */ }
}
```

## Verification

- `npm --prefix cli run typecheck` passes.
- Repro harness: without the fix, `mkdir` on a pointer file throws `EEXIST`; with it, `data` becomes a real directory with the copied contents, and a pre-existing real directory is preserved on re-install.

## Scope

- 20-line change to `cli/src/utils/template.ts`, no behavior change for clean installs.
- Distinct from the in-repo symlink work in #336/#368 (those only touch `.claude/skills/`, not the CLI installer).

Closes #237
