### PR TITLE
fix(scripts): guard persist_design_system against None project_name (#159)

### DIFF
--- a/cli/assets/scripts/design_system.py
+++ b/cli/assets/scripts/design_system.py
@@ -573,8 +573,9 @@ def persist_design_system(design_system: dict, page: str = None, output_dir: str
     """
     base_dir = Path(output_dir) if output_dir else Path.cwd()
     
-    # Use project name for project-specific folder
-    project_name = design_system.get("project_name", "default")
+    # Use project name for project-specific folder. Coalesce falsy values
+    # (missing key, explicit None, or "") so the .lower() below can't crash.
+    project_name = design_system.get("project_name") or "default"
     project_slug = project_name.lower().replace(' ', '-')
     
     design_system_dir = base_dir / "design-system" / project_slug

--- a/src/ui-ux-pro-max/scripts/design_system.py
+++ b/src/ui-ux-pro-max/scripts/design_system.py
@@ -573,8 +573,9 @@ def persist_design_system(design_system: dict, page: str = None, output_dir: str
     """
     base_dir = Path(output_dir) if output_dir else Path.cwd()
     
-    # Use project name for project-specific folder
-    project_name = design_system.get("project_name", "default")
+    # Use project name for project-specific folder. Coalesce falsy values
+    # (missing key, explicit None, or "") so the .lower() below can't crash.
+    project_name = design_system.get("project_name") or "default"
     project_slug = project_name.lower().replace(' ', '-')
     
     design_system_dir = base_dir / "design-system" / project_slug


### PR DESCRIPTION
## What & why

`persist_design_system` crashes with `AttributeError: 'NoneType' object has no attribute 'lower'` (#159) when the `design_system` dict carries an explicit `project_name` of `None`:

```python
project_name = design_system.get("project_name", "default")  # returns None when key is present-but-None
project_slug = project_name.lower().replace(' ', '-')        # 💥
```

`dict.get(key, default)` only substitutes the default for a **missing** key, not a present-but-`None` value — and `generate(query, project_name=None)` is the documented default, so a `None` reaches here easily.

## Fix

Coalesce falsy values (`None` / `""` / missing) to `"default"` before slugifying:

```python
project_name = design_system.get("project_name") or "default"
```

Applied to both the source of truth (`src/ui-ux-pro-max/scripts/`) and the bundled `cli/assets/` copy.

## Verification

```text
project_name=None          -> OK (no crash)
project_name=''            -> OK (no crash)
project_name='My Cool App' -> OK (no crash)
missing key                -> OK (no crash)
```
`npm run check:assets` passes (both copies in sync).

## Scope

#159 also cited the `core.py` tokenize length filter ("search blindness"); that's **already resolved on `main`** (`len(w) >= 2`), so this PR targets only the remaining crash.

Supersedes #160 (same root cause; this version coalesces `""` as well and keeps the two script copies in sync). Credit to @YangKuoshih for the original diagnosis and fix.

Closes #159
