### PR TITLE
fix(cli): make uipro update actually upgrade the CLI via npm (supersedes #326)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,7 +33,7 @@ uipro init --force          # Overwrite existing files
 
 # Other commands
 uipro versions              # List available versions
-uipro update                # Refresh skill files from installed CLI package
+uipro update                # Update the global CLI to the latest release
 ```
 
 ## GitHub Authentication
@@ -63,12 +63,14 @@ uipro init
 
 ## How It Works
 
-`uipro init` generates assistant-specific files from the templates bundled with the installed CLI package. To get newer templates and data, update the package first:
+`uipro init` generates assistant-specific files from the templates bundled with the installed CLI package. To get newer templates and data, update the package, then regenerate:
 
 ```bash
-npm install -g uipro-cli@latest
-uipro init --ai codex
+uipro update                   # updates the global CLI to the latest release
+uipro init --ai codex --force  # regenerate skill files from the new package
 ```
+
+`uipro update` runs `npm install -g uipro-cli@latest` for you (it shells out to `npm` only on Windows, where `npm` is a `.cmd`). You can still run that command manually if you prefer. When the CLI is already current, `uipro update` just refreshes the installed skill files.
 
 ## Development
 

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,9 +39,38 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
 
     if (currentVersion !== latestVersion) {
       console.log();
-      logger.warn(`Installed CLI package is ${chalk.cyan(currentVersion)}, but latest release is ${chalk.cyan(release.tag_name)}.`);
-      logger.info(`Update the CLI package first: ${chalk.cyan(`npm install -g uipro-cli@${latestVersion}`)}`);
-      logger.info('Then rerun: uipro init --ai <platform>');
+
+      // Only auto-run with a well-formed semver, so nothing unexpected can
+      // reach the shell that npm.cmd requires on Windows.
+      if (!/^\d+\.\d+\.\d+([.-][0-9A-Za-z.-]+)?$/.test(latestVersion)) {
+        logger.warn(`Installed CLI is ${chalk.cyan(currentVersion)}; latest release is ${chalk.cyan(release.tag_name)}.`);
+        logger.info(`Update the CLI package: ${chalk.cyan(`npm install -g uipro-cli@${latestVersion}`)}`);
+        logger.info('Then rerun: uipro init --ai <platform> --force');
+        return;
+      }
+
+      logger.info(`Updating CLI from ${chalk.cyan(currentVersion)} to ${chalk.cyan(latestVersion)}...`);
+      console.log();
+
+      const isWindows = process.platform === 'win32';
+      try {
+        // execFileSync with an explicit args array — no shell string to expand.
+        // On Windows npm is npm.cmd, which Node only spawns via a shell.
+        execFileSync(
+          isWindows ? 'npm.cmd' : 'npm',
+          ['install', '-g', `uipro-cli@${latestVersion}`],
+          { stdio: 'inherit', shell: isWindows }
+        );
+      } catch {
+        console.log();
+        logger.error('Automatic update failed (you may need elevated/admin permissions).');
+        logger.info(`Update manually: ${chalk.cyan(`npm install -g uipro-cli@${latestVersion}`)}`);
+        process.exit(1);
+      }
+
+      console.log();
+      logger.success(`Updated to ${chalk.cyan(latestVersion)}.`);
+      logger.info(`Now rerun ${chalk.cyan('uipro init --ai <platform> --force')} to refresh your skill files.`);
       return;
     }
 


### PR DESCRIPTION
## What & why

`uipro update` checked the latest release but, when the installed CLI was behind, only **printed** `npm install -g uipro-cli@…` and returned — it never actually upgraded. Users stayed on stale assets (the root of #353 for npm consumers). This makes `uipro update` perform the upgrade itself.

## Change

When the installed version is behind the latest release, `updateCommand` now runs the global install:

```ts
execFileSync(
  isWindows ? 'npm.cmd' : 'npm',
  ['install', '-g', `uipro-cli@${latestVersion}`],
  { stdio: 'inherit', shell: isWindows }
);
```

Addressing the review on #326:

- **`execFileSync` with an explicit args array** instead of `execSync('npm install -g …')` — no shell string is built or expanded on the common path.
- **Windows:** `npm` is `npm.cmd`, which Node refuses to spawn without a shell since CVE-2024-27980, so Windows uses `npm.cmd` + `shell: true`; **POSIX runs with no shell at all**.
- **Injection-safe:** `latestVersion` is validated as semver (`/^\d+\.\d+\.\d+([.-][0-9A-Za-z.-]+)?$/`) before it can reach the Windows shell — e.g. a tag like `2.7.0; rm -rf /` is rejected and falls back to manual instructions.
- **Failure handling:** if the install fails (e.g. needs admin), it prints the manual command and exits non-zero.
- **Post-update guidance:** on success it tells the user to rerun `uipro init --ai <platform> --force` (the maintainer's suggestion). README updated to match.

## Verification

- `npm run typecheck` passes.
- Version-guard unit check: accepts `2.7.0`, `2.8.0-beta.1`; rejects `2.7.0; rm -rf /`, `latest && evil`, empty.

(Can't exercise a real global install in CI without side effects; the install path is `execFileSync` with a validated static arg array.)

Supersedes #326 (resolves the `execSync`/shell review finding + Windows `.cmd` handling + version validation). Credit to @alfredo-petri for the original fix.
