### PR TITLE
fix(scripts): force UTF-8 stdout in design_system.py on Windows (#112)

### DIFF
--- a/cli/assets/scripts/design_system.py
+++ b/cli/assets/scripts/design_system.py
@@ -16,9 +16,17 @@ Usage:
 import csv
 import json
 import os
+import sys
+import io
 from datetime import datetime
 from pathlib import Path
 from core import search, DATA_DIR
+
+# Force UTF-8 for stdout/stderr to handle emojis/box-drawing chars on Windows (cp1252 default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 
 # ============ CONFIGURATION ============

--- a/src/ui-ux-pro-max/scripts/design_system.py
+++ b/src/ui-ux-pro-max/scripts/design_system.py
@@ -16,9 +16,17 @@ Usage:
 import csv
 import json
 import os
+import sys
+import io
 from datetime import datetime
 from pathlib import Path
 from core import search, DATA_DIR
+
+# Force UTF-8 for stdout/stderr to handle emojis/box-drawing chars on Windows (cp1252 default)
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 
 # ============ CONFIGURATION ============


### PR DESCRIPTION
## What & why

On a non-UTF-8 Windows console (cp1252/gbk), running `design_system.py` as a CLI crashes with `UnicodeEncodeError` -- the same class of failure reported in #112 for `search.py`. The script prints box-drawing characters, check marks, and block swatches, but unlike `search.py` it never reconfigured stdout.

Note: the `search.py` instance from #112 is **already fixed on main** (it wraps stdout/stderr in a UTF-8 `TextIOWrapper` at lines 23-27). This PR covers the remaining `design_system.py` gap.

## Change

Mirror `search.py`'s wrapper in `design_system.py`:

```python
if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
```

Applied to the source of truth (`src/ui-ux-pro-max/scripts/`) and the synced `cli/assets/` copy. The check is idempotent, so it is a no-op when `search.py` imports `design_system` (stdout is already UTF-8 by then).

## Verification

- `PYTHONIOENCODING=cp1252 python design_system.py "saas dashboard" --format ascii` -> exit 0, no `UnicodeEncodeError`, still emits the box/swatch output (50 lines with non-ASCII).
- `npm run check:assets` passes (both copies in sync).

Related to #112.
