### PR TITLE
fix(cli): keep the uipro bin from being stripped on npm publish (#353)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",
   "bin": {
-    "uipro": "./dist/index.js"
+    "uipro": "dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## What & why

Per @mrgoonie's latest recheck on #353: the release workflow now runs and attempts `npm publish`, but npm warns `bin[uipro] script name dist/index.js was invalid and removed`. The cause is the bin value `"./dist/index.js"` -- npm normalizes bin paths on publish, and the leading `./` gets "cleaned"; on the npm version in the release runner that means the entry is **dropped**, so a published package would ship with **no `uipro` command** (`npx uipro-cli init` would fail even after publishing succeeds).

## Change

`cli/package.json`:
```diff
-    "uipro": "./dist/index.js"
+    "uipro": "dist/index.js"
```

This is exactly what `npm pkg fix` produces. `src/index.ts` already starts with `#!/usr/bin/env node`, which `bun build` preserves, so the bin target is executable.

## Verification

- `npm publish --dry-run` no longer emits the `bin[uipro] ... invalid/cleaned` warning (reproduced before, clean after).
- `dist/index.js` is included in the tarball; `npm run typecheck` passes.

## Scope (what this does and does not do)

This is the **package-metadata** half of #353 that @mrgoonie scoped first. It does **not** by itself make the registry update -- per `npm owner ls uipro-cli`, the package is owned by `viettranx`, so the release still needs a tagged run with an `NPM_TOKEN` that has **publish rights for `uipro-cli`**.

Acceptance after this merges + a release with a valid-rights token:
- release job completes `npm publish`
- `npm view uipro-cli version` reports the current tag
- `npm view uipro-cli bin --json` exposes a valid `uipro` command
- `npx --yes uipro-cli@<new-version> init --ai claude` installs current assets

Addresses #353.
