### PR TITLE
fix(cli): publish under fallback npm package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/ui-ux-pro-max/                # Source of Truth
     ├── base/                     # Base templates (skill-content.md, quick-reference.md)
     └── platforms/                # Platform configs (claude.json, cursor.json, ...)
 
-cli/                              # CLI installer (uipro-cli on npm)
+cli/                              # CLI installer (ui-ux-pro-max-cli on npm)
 ├── src/
 │   ├── commands/init.ts          # Install command with template generation
 │   └── utils/template.ts         # Template rendering engine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ ui-ux-pro-max-skill/
 │   ├── data/                   # CSV databases (styles, colors, typography, rules)
 │   ├── scripts/                # Python search engine & design system generator
 │   └── templates/              # Platform-specific skill templates
-├── cli/                        # npm CLI installer (uipro-cli)
+├── cli/                        # npm CLI installer (ui-ux-pro-max-cli)
 ├── .claude/                    # Local dev/test files for Claude Code
 ├── .factory/                   # Local dev/test files for Droid (Factory)
 ├── docs/                       # Documentation
@@ -140,7 +140,7 @@ Types:
 feat: add Skeuomorphism 2.0 style to general styles
 fix: correct color palette for fintech industry rule
 docs: translate README to Spanish
-chore: update uipro-cli to v2.6.0
+chore: update ui-ux-pro-max-cli to v2.6.0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/uipro-cli"><img src="https://img.shields.io/npm/v/uipro-cli?style=flat-square&logo=npm&label=CLI" alt="npm"></a>
-  <a href="https://www.npmjs.com/package/uipro-cli"><img src="https://img.shields.io/npm/dm/uipro-cli?style=flat-square&label=downloads" alt="npm downloads"></a>
+  <a href="https://www.npmjs.com/package/ui-ux-pro-max-cli"><img src="https://img.shields.io/npm/v/ui-ux-pro-max-cli?style=flat-square&logo=npm&label=CLI" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/ui-ux-pro-max-cli"><img src="https://img.shields.io/npm/dm/ui-ux-pro-max-cli?style=flat-square&label=downloads" alt="npm downloads"></a>
   <a href="https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/stargazers"><img src="https://img.shields.io/github/stars/nextlevelbuilder/ui-ux-pro-max-skill?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://paypal.me/uiuxpromax"><img src="https://img.shields.io/badge/PayPal-Support%20Development-00457C?style=flat-square&logo=paypal&logoColor=white" alt="PayPal"></a>
 </p>
@@ -266,7 +266,7 @@ Install directly in Claude Code with two commands:
 
 ```bash
 # Install CLI globally
-npm install -g uipro-cli
+npm install -g ui-ux-pro-max-cli
 
 # Go to your project
 cd /path/to/your/project
@@ -292,6 +292,8 @@ uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
 uipro init --ai all         # All assistants
 ```
+
+The npm package is `ui-ux-pro-max-cli`; it still installs the `uipro` command. Older `uipro-cli` releases are stale and should not be used for current assets.
 
 ### Global Install (Available for All Projects)
 
@@ -464,7 +466,7 @@ The codebase has been restructured to use a **template-based generation system**
 **Always use the CLI to install:**
 
 ```bash
-npm install -g uipro-cli
+npm install -g ui-ux-pro-max-cli
 uipro init --ai <platform>
 ```
 
@@ -524,16 +526,16 @@ Use these commit types for correct version bumps:
 - `feat:` -> minor release
 - `feat!:` or `BREAKING CHANGE:` -> major release
 
-The release workflow only needs the default `GITHUB_TOKEN`; it does not publish to npm.
+The release workflow uses the default `GITHUB_TOKEN` for GitHub releases and the repository `NPM_TOKEN` secret to publish `ui-ux-pro-max-cli` to npm.
 
 ## Troubleshooting
 
 ### `uipro: unknown command 'uninstall'` or `unknown command 'update'`
 
-Your installed version of `uipro-cli` is outdated. Update it and retry:
+Your installed version of `ui-ux-pro-max-cli` is outdated. Update it and retry:
 
 ```bash
-npm install -g uipro-cli@latest
+npm install -g ui-ux-pro-max-cli@latest
 uipro uninstall
 ```
 
@@ -561,20 +563,20 @@ rm -rf .agents/skills/ui-ux-pro-max   # Antigravity
 This is a known issue with versions prior to v2.5.1. The repository used symlinks internally which some installation tools can't handle. **Fix:** use the CLI installer instead:
 
 ```bash
-npm install -g uipro-cli
+npm install -g ui-ux-pro-max-cli
 uipro init --ai claude
 ```
 
 Or wait for the next release where this is resolved.
 
-### `npm install -g uipro-cli` fails with permission error
+### `npm install -g ui-ux-pro-max-cli` fails with permission error
 
 ```bash
 # macOS/Linux — use a Node version manager (recommended) or sudo
-sudo npm install -g uipro-cli
+sudo npm install -g ui-ux-pro-max-cli
 
 # Or use npx without installing globally
-npx uipro-cli init --ai claude
+npx ui-ux-pro-max-cli init --ai claude
 ```
 
 ### Python not found when running design system commands

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,11 +1,11 @@
-# uipro-cli
+# ui-ux-pro-max-cli
 
 CLI to install UI/UX Pro Max skill for AI coding assistants.
 
 ## Installation
 
 ```bash
-npm install -g uipro-cli
+npm install -g ui-ux-pro-max-cli
 ```
 
 ## Usage
@@ -70,7 +70,7 @@ uipro update                   # updates the global CLI to the latest release
 uipro init --ai codex --force  # regenerate skill files from the new package
 ```
 
-`uipro update` runs `npm install -g uipro-cli@latest` for you (it shells out to `npm` only on Windows, where `npm` is a `.cmd`). You can still run that command manually if you prefer. When the CLI is already current, `uipro update` just refreshes the installed skill files.
+`uipro update` runs `npm install -g ui-ux-pro-max-cli@latest` for you (it shells out to `npm` only on Windows, where `npm` is a `.cmd`). You can still run that command manually if you prefer. When the CLI is already current, `uipro update` just refreshes the installed skill files.
 
 ## Development
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "uipro-cli",
+  "name": "ui-ux-pro-max-cli",
   "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uipro-cli",
+      "name": "ui-ux-pro-max-cli",
       "version": "2.5.0",
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uipro-cli",
+  "name": "ui-ux-pro-max-cli",
   "version": "2.5.0",
   "description": "CLI to install UI/UX Pro Max skill for AI coding assistants",
   "type": "module",

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -10,6 +10,7 @@ import { initCommand } from './init.js';
 import type { AIType } from '../types/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PACKAGE_NAME = 'ui-ux-pro-max-cli';
 
 interface UpdateOptions {
   ai?: AIType;
@@ -44,7 +45,7 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
       // reach the shell that npm.cmd requires on Windows.
       if (!/^\d+\.\d+\.\d+([.-][0-9A-Za-z.-]+)?$/.test(latestVersion)) {
         logger.warn(`Installed CLI is ${chalk.cyan(currentVersion)}; latest release is ${chalk.cyan(release.tag_name)}.`);
-        logger.info(`Update the CLI package: ${chalk.cyan(`npm install -g uipro-cli@${latestVersion}`)}`);
+        logger.info(`Update the CLI package: ${chalk.cyan(`npm install -g ${CLI_PACKAGE_NAME}@${latestVersion}`)}`);
         logger.info('Then rerun: uipro init --ai <platform> --force');
         return;
       }
@@ -58,13 +59,13 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
         // On Windows npm is npm.cmd, which Node only spawns via a shell.
         execFileSync(
           isWindows ? 'npm.cmd' : 'npm',
-          ['install', '-g', `uipro-cli@${latestVersion}`],
+          ['install', '-g', `${CLI_PACKAGE_NAME}@${latestVersion}`],
           { stdio: 'inherit', shell: isWindows }
         );
       } catch {
         console.log();
         logger.error('Automatic update failed (you may need elevated/admin permissions).');
-        logger.info(`Update manually: ${chalk.cyan(`npm install -g uipro-cli@${latestVersion}`)}`);
+        logger.info(`Update manually: ${chalk.cyan(`npm install -g ${CLI_PACKAGE_NAME}@${latestVersion}`)}`);
         process.exit(1);
       }
 

--- a/cli/src/utils/github.ts
+++ b/cli/src/utils/github.ts
@@ -4,6 +4,7 @@ import type { Release } from '../types/index.js';
 const REPO_OWNER = 'nextlevelbuilder';
 const REPO_NAME = 'ui-ux-pro-max-skill';
 const API_BASE = 'https://api.github.com';
+const USER_AGENT = 'ui-ux-pro-max-cli';
 
 export class GitHubRateLimitError extends Error {
   constructor(message: string) {
@@ -56,7 +57,7 @@ export async function fetchReleases(token?: string): Promise<Release[]> {
   const response = await fetch(url, {
     headers: {
       'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'uipro-cli',
+      'User-Agent': USER_AGENT,
       ...getAuthHeaders(token),
     },
   });
@@ -76,7 +77,7 @@ export async function getLatestRelease(token?: string): Promise<Release> {
   const response = await fetch(url, {
     headers: {
       'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'uipro-cli',
+      'User-Agent': USER_AGENT,
       ...getAuthHeaders(token),
     },
   });
@@ -93,7 +94,7 @@ export async function getLatestRelease(token?: string): Promise<Release> {
 export async function downloadRelease(url: string, dest: string, token?: string): Promise<void> {
   const response = await fetch(url, {
     headers: {
-      'User-Agent': 'uipro-cli',
+      'User-Agent': USER_AGENT,
       'Accept': 'application/octet-stream',
       ...getAuthHeaders(token),
     },

--- a/docs/三个 data-scripts-templates 的区别.md
+++ b/docs/三个 data-scripts-templates 的区别.md
@@ -6,7 +6,7 @@
 |------|------|--------|
 | **src/ui-ux-pro-max/** | **唯一源码**。所有 CSV、脚本、模板都在这里改，是“唯一真相来源”。 | ❌ 不能删，这是你要维护的那一份。 |
 | **.claude/skills/ui-ux-pro-max/** | 给 **Cursor / Claude Code** 用的 Skill。AI 从这里读 SKILL.md 和运行 `scripts/search.py`。设计上这里的 data、scripts 应是**指向 src 的符号链接**，这样不用维护两份。 | ❌ 不能删（否则 Skill 不工作）；但可以改成只链到 src，不保留副本。 |
-| **cli/assets/** | 给 **npm 包 uipro-cli** 打包用。用户执行 `npm i -g uipro-cli` 再 `uipro init` 时，安装的是这里打包进去的 data/scripts/templates。 | ❌ 不能删；发布前用脚本从 src 同步过来即可。 |
+| **cli/assets/** | 给 **npm 包 ui-ux-pro-max-cli** 打包用。用户执行 `npm i -g ui-ux-pro-max-cli` 再 `uipro init` 时，安装的是这里打包进去的 data/scripts/templates。 | ❌ 不能删；发布前用脚本从 src 同步过来即可。 |
 
 ## 可以只保留一个吗？
 

--- a/skill.json
+++ b/skill.json
@@ -38,5 +38,5 @@
     "antigravity",
     "openclaw"
   ],
-  "install": "npx uipro-cli init --ai {{platform}}"
+  "install": "npx ui-ux-pro-max-cli init --ai {{platform}}"
 }


### PR DESCRIPTION
## Summary

Switches the npm package identity from `uipro-cli` to `ui-ux-pro-max-cli` while preserving the installed `uipro` binary command.

## Why

Issue #353 is still blocked on npm ownership for the official `uipro-cli` package. The repository release pipeline can build the correct package, but the current `NPM_TOKEN` authenticates as `mrgoonie` while `npm owner ls uipro-cli` still lists only `viettranx`. This PR applies the maintainer fallback decision to publish under a different package name.

## Changes

- Rename `cli/package.json` and `cli/package-lock.json` to `ui-ux-pro-max-cli`.
- Update `uipro update` so automatic/manual updates install `ui-ux-pro-max-cli@<version>`.
- Update GitHub request user agent to the new package name.
- Update README, CLI README, `skill.json`, and contributor/docs references to use `ui-ux-pro-max-cli`.
- Keep `bin.uipro = dist/index.js`, so user commands remain `uipro ...` after install.

## Verification

- `npm view uipro-cli version` still returns `2.2.3`.
- `npm owner ls uipro-cli` still lists only `viettranx <viettranx@gmail.com>`.
- Current `NPM_TOKEN` identity check returns `mrgoonie`, so it cannot publish `uipro-cli`.
- `npm view ui-ux-pro-max-cli version` returns 404, so the fallback package name is available.
- `npm --prefix cli run check:assets` passes.
- `npm --prefix cli run typecheck` passes.
- `npm exec --yes --package bun -- bun build src/index.ts --outdir dist --target node` passes.
- `npm publish --dry-run --json` from `cli/` passes and reports `ui-ux-pro-max-cli@2.5.0` with `dist/index.js` included.

Closes #353 after a release proves npm publish and clean install succeed.
