### PR TITLE
docs: sync CLAUDE.md stack list with core.py STACK_CONFIG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ python3 src/ui-ux-pro-max/scripts/search.py "<query>" --domain <domain> [-n <max
 ```bash
 python3 src/ui-ux-pro-max/scripts/search.py "<query>" --stack <stack>
 ```
-Available stacks: `html-tailwind` (default), `react`, `nextjs`, `astro`, `vue`, `nuxtjs`, `nuxt-ui`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`, `angular`, `laravel`, `javafx`
+Available stacks: `html-tailwind` (default), `react`, `nextjs`, `astro`, `vue`, `nuxtjs`, `nuxt-ui`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`, `threejs`, `angular`, `laravel`, `javafx`, `wpf`, `winui`, `avalonia`, `uno`, `uwp`
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s "Available stacks" list only mentioned 16 of the 22 stacks defined in `STACK_CONFIG` (`src/ui-ux-pro-max/scripts/core.py`), silently omitting `threejs`, `wpf`, `winui`, `avalonia`, `uno`, and `uwp`.
- Updated the list so it matches `STACK_CONFIG` exactly, so contributors and AI assistants reading `CLAUDE.md` know these stacks are valid `--stack` values.

## Test plan
- [x] Diffed `CLAUDE.md`'s stack list against the keys of `STACK_CONFIG` in `core.py` to confirm all 22 are now present and none were added incorrectly.
- [x] Docs-only change, no code/runtime behavior affected.