### PR TITLE
docs: fix Premium tier domain typo in README (uipm.cc -> uupm.cc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Many users ask about the differences between the open-source and premium version
 * **Enterprise Architecture:** A more comprehensive and scalable Design Token architecture, built for large-scale team deployments.
 * **Priority Support:** Dedicated technical assistance for teams and professionals who need an uninterrupted full design workflow.
 
-👉 *For more details on upgrading to the Premium tier, visit [uipm.cc](https://uipm.cc).*
+👉 *For more details on upgrading to the Premium tier, visit [uupm.cc](https://uupm.cc).*
 
 ## Installation
 


### PR DESCRIPTION
## What

Fixes a typo in the English README: the Premium tier section linked to `uipm.cc` instead of the project domain `uupm.cc`.

## Why

Every other reference in the repo uses `uupm.cc` — the README title link, the `homepage` field in `skill.json`, and the equivalent line in `README.zh.md`. Only this one line pointed readers to the wrong domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)