### PR TITLE
chore: bump version to 2.11.0 in skill metadata files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "UI/UX design intelligence skill with 84 styles, 161 palettes, 73 font pairings, 25 charts, and 17 stack guidelines",
-    "version": "2.6.2"
+    "version": "2.11.0"
   },
   "plugins": [
     {
       "name": "ui-ux-pro-max",
       "source": "./",
       "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, and Three.js.",
-      "version": "2.6.2",
+      "version": "2.11.0",
       "author": {
         "name": "nextlevelbuilder"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-ux-pro-max",
   "description": "UI/UX design intelligence. Searchable local database with 84 styles, 161 palettes, 73 font pairings, 25 charts, and 17 stacks (React, Next.js, Vue, Nuxt.js, Nuxt UI, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, Three.js). Use when designing, building, or reviewing UI: pages, components, color schemes, typography, layout, accessibility, animation, or data visualization.",
-  "version": "2.6.2",
+  "version": "2.11.0",
   "author": {
     "name": "nextlevelbuilder"
   },

--- a/skill.json
+++ b/skill.json
@@ -2,7 +2,7 @@
   "name": "ui-ux-pro-max",
   "displayName": "UI/UX Pro Max",
   "description": "AI-powered design intelligence with 84 UI styles, 161 color palettes, 73 font pairings, 99 UX guidelines, and 25 chart types across 17 tech stacks.",
-  "version": "2.6.2",
+  "version": "2.11.0",
   "author": "NextLevelBuilder",
   "license": "MIT",
   "homepage": "https://uupm.cc",


### PR DESCRIPTION
## Summary

Bump the version field from 2.6.2 to 2.11.0 across three metadata files to keep them in sync with the latest CLI release (v2.11.0).

## Changes

| File | Change |
|------|--------|
| `skill.json` | version: 2.6.2 → 2.11.0 |
| `.claude-plugin/plugin.json` | version: 2.6.2 → 2.11.0 |
| `.claude-plugin/marketplace.json` | version: 2.6.2 → 2.11.0 (2 occurrences) |

## Context

The CLI package on npm is already at v2.11.0, but these three metadata files still reference 2.6.2. This PR aligns them with the current release.