### PR TITLE
docs: fix stale stats in skill.json and marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "name": "nextlevelbuilder"
   },
   "metadata": {
-    "description": "UI/UX design intelligence skill with 84 styles, 161 palettes, 73 font pairings, 25 charts, and 17 stack guidelines",
+    "description": "UI/UX design intelligence skill with 84 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stack guidelines",
     "version": "2.11.0"
   },
   "plugins": [

--- a/skill.json
+++ b/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-ux-pro-max",
   "displayName": "UI/UX Pro Max",
-  "description": "AI-powered design intelligence with 84 UI styles, 161 color palettes, 73 font pairings, 99 UX guidelines, and 25 chart types across 17 tech stacks.",
+  "description": "AI-powered design intelligence with 84 UI styles, 192 color palettes, 74 font pairings, 98 UX guidelines, and 25 chart types across 22 tech stacks.",
   "version": "2.11.0",
   "author": "NextLevelBuilder",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- `skill.json` and `.claude-plugin/marketplace.json` still described 161 color palettes, 73 font pairings, 99 UX guidelines, and 17 tech stacks
- These numbers predate the current data set; `README.md` and `.claude-plugin/plugin.json` already report the correct counts (192 palettes, 74 pairings, 98 guidelines, 22 stacks)
- Updated both files so the metadata is consistent across the repo

## Test plan
- [x] Verified actual counts against `src/ui-ux-pro-max/data/colors.csv` (192 rows), `typography.csv` (74 rows), `ux-guidelines.csv` (98 rows), and `src/ui-ux-pro-max/data/stacks/` (22 files)
- [x] Confirmed the corrected numbers match `README.md` and `.claude-plugin/plugin.json`
- [x] Validated both edited files are still valid JSON

Docs-only change, no data/script/template edits, no sync step required.