### PR TITLE
docs: don't hardcode React Native as the project stack

### DIFF
--- a/cli/assets/templates/base/skill-content.md
+++ b/cli/assets/templates/base/skill-content.md
@@ -42,7 +42,12 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: whatever the user is actually building with — infer it from the project
+  (package.json, existing files, explicit request) or ask. Then load its rules with
+  `--stack <name>` (see "Available Stacks"). Do not assume React Native.
+- **Platform**: web or native app. Several sections below are scoped to App UI
+  (iOS/Android/React Native/Flutter) and do not apply to desktop-web work —
+  safe areas, haptics, bottom nav and Dynamic Type are mobile-only concerns.
 
 ### Step 2: Generate Design System (REQUIRED)
 

--- a/src/ui-ux-pro-max/templates/base/skill-content.md
+++ b/src/ui-ux-pro-max/templates/base/skill-content.md
@@ -42,7 +42,12 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: whatever the user is actually building with — infer it from the project
+  (package.json, existing files, explicit request) or ask. Then load its rules with
+  `--stack <name>` (see "Available Stacks"). Do not assume React Native.
+- **Platform**: web or native app. Several sections below are scoped to App UI
+  (iOS/Android/React Native/Flutter) and do not apply to desktop-web work —
+  safe areas, haptics, bottom nav and Dynamic Type are mobile-only concerns.
 
 ### Step 2: Generate Design System (REQUIRED)
 


### PR DESCRIPTION
## What does this PR change?

Step 1 of the workflow in `skill-content.md` tells the agent that the stack is always React Native. This PR replaces that with stack inference + an explicit platform (web vs native) question, and points at the `Available Stacks` list.

## Why?

The line reads:

```
- **Stack**: React Native (this project's only tech stack)
```

It looks like a leftover from the skill's origin as a React Native project, but in a general-purpose skill shipping 22 stack guides it actively misleads the agent. Two observed consequences when using the skill to build a plain HTML + Tailwind landing page:

1. **The matching `--stack` file is never loaded.** `html-tailwind.csv` (55 rules) exists and was exactly the right one, but nothing in the workflow pointed there — Step 1 had already declared the stack.
2. **Mobile guidance leaks into web output.** `--design-system` returned effects written in React Native terms (`Reanimated translateX`, `BlurView intensity 20`, `haptic Impact Light`) for a web target. The file's own `Scope notice` lines already say several rule sets are App UI only, but nothing earlier in the workflow establishes which platform is in play.

The second hunk makes that platform scoping explicit up front, so mobile-only concerns (safe areas, haptics, bottom nav, Dynamic Type) are not applied to desktop-web work.

Docs-only change; no data or script behavior is touched.

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/`
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` (reports `Assets are in sync.`)
- [ ] Added or updated tests if behavior changed — n/a, documentation only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] This PR targets a feature branch, not pushed directly to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)