### PR TITLE
fix(codex): install skills under .agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ uipro uninstall --global
 rm -rf .claude/skills/ui-ux-pro-max   # Claude Code
 rm -rf .cursor/skills/ui-ux-pro-max   # Cursor
 rm -rf .windsurf/skills/ui-ux-pro-max # Windsurf
-rm -rf .agents/skills/ui-ux-pro-max   # Antigravity
+rm -rf .agents/skills/ui-ux-pro-max   # Antigravity / Codex
 ```
 
 ### Claude Marketplace install fails with "Zip file contains a symbolic link"

--- a/README.zh.md
+++ b/README.zh.md
@@ -572,7 +572,7 @@ uipro uninstall --global
 rm -rf .claude/skills/ui-ux-pro-max   # Claude Code
 rm -rf .cursor/skills/ui-ux-pro-max   # Cursor
 rm -rf .windsurf/skills/ui-ux-pro-max # Windsurf
-rm -rf .agents/skills/ui-ux-pro-max   # Antigravity
+rm -rf .agents/skills/ui-ux-pro-max   # Antigravity / Codex
 ```
 
 ### Claude Marketplace 安装失败，提示 "Zip file contains a symbolic link"

--- a/cli/assets/templates/platforms/codex.json
+++ b/cli/assets/templates/platforms/codex.json
@@ -3,7 +3,7 @@
   "displayName": "Codex",
   "installType": "full",
   "folderStructure": {
-    "root": ".codex",
+    "root": ".agents",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -19,7 +19,10 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.windsurf'))) {
     detected.push('windsurf');
   }
-  if (existsSync(join(cwd, '.agents')) || existsSync(join(cwd, '.agent'))) {
+  if (existsSync(join(cwd, '.agents'))) {
+    detected.push('antigravity');
+    detected.push('codex');
+  } else if (existsSync(join(cwd, '.agent'))) {
     detected.push('antigravity');
   }
   if (existsSync(join(cwd, '.github'))) {
@@ -28,7 +31,7 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.kiro'))) {
     detected.push('kiro');
   }
-  if (existsSync(join(cwd, '.codex'))) {
+  if (existsSync(join(cwd, '.codex')) && !detected.includes('codex')) {
     detected.push('codex');
   }
   if (existsSync(join(cwd, '.roo'))) {
@@ -72,6 +75,13 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   let suggested: AIType | null = null;
   if (detected.length === 1) {
     suggested = detected[0];
+  } else if (
+    detected.length === 2 &&
+    detected.includes('antigravity') &&
+    detected.includes('codex')
+  ) {
+    // Both platforms share `.agents`; avoid suggesting an install for every AI.
+    suggested = 'codex';
   } else if (detected.length > 1) {
     suggested = 'all';
   }

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -94,7 +94,7 @@ export function getAITypeDescription(aiType: AIType): string {
     case 'kiro':
       return 'Kiro (.kiro/steering/)';
     case 'codex':
-      return 'Codex (.codex/skills/)';
+      return 'Codex (.agents/skills/)';
     case 'roocode':
       return 'RooCode (.roo/skills/)';
     case 'qoder':

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -294,10 +294,20 @@ export async function generatePlatformFiles(
  */
 export async function generateAllPlatformFiles(targetDir: string, isGlobal = false, force = false): Promise<string[]> {
   const allFolders = new Set<string>();
+  const generatedSkillFiles = new Set<string>();
 
   for (const aiType of Object.keys(AI_TO_PLATFORM)) {
     try {
+      const config = await loadPlatformConfig(aiType);
+      const skillFile = join(
+        config.folderStructure.root,
+        config.folderStructure.skillPath,
+        config.folderStructure.filename
+      );
+      if (generatedSkillFiles.has(skillFile)) continue;
+
       const folders = await generatePlatformFiles(targetDir, aiType, isGlobal, force);
+      generatedSkillFiles.add(skillFile);
       folders.forEach(f => allFolders.add(f));
     } catch {
       // Skip if generation fails for a platform

--- a/src/ui-ux-pro-max/templates/platforms/codex.json
+++ b/src/ui-ux-pro-max/templates/platforms/codex.json
@@ -3,7 +3,7 @@
   "displayName": "Codex",
   "installType": "full",
   "folderStructure": {
-    "root": ".codex",
+    "root": ".agents",
     "skillPath": "skills/ui-ux-pro-max",
     "filename": "SKILL.md"
   },


### PR DESCRIPTION
## What does this PR change?

- Installs Codex skills under `.agents/skills/` in the source and packaged platform templates.
- Reports a shared `.agents` directory as both Codex and Antigravity, while suggesting Codex instead of `all` when those are the only matches.
- Generates each shared skill target once during `--ai all`, so `--force` cannot replace it with a later platform template.
- Labels the shared `.agents` uninstall path for both platforms in the English and Chinese READMEs.

## Why?

Codex discovers repository skills from `.agents/skills`, including at the repository root. The previous `.codex/skills` target was not loaded as a repo-scoped skill location. Because Antigravity already uses `.agents`, moving Codex there also requires shared-target handling to keep detection and `--ai all` deterministic. See the [OpenAI skill documentation](https://learn.chatgpt.com/docs/build-skills).

## Verification

- `npm run check:assets`
- TypeScript type-check and compilation with the local compiler
- Fresh `uipro init --ai codex --offline` smoke test created `.agents/skills/ui-ux-pro-max/SKILL.md`, preserved the Codex quick reference, and created no `.codex` directory
- Shared `.agents` detection returned `antigravity` and `codex` with `codex` suggested
- `uipro init --ai all --offline` produced the same shared skill before and after rerunning with `--force`
- Stale-path scan found no Codex `.codex/skills` display or Antigravity-only label for the shared uninstall command

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/`
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed
- [ ] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`) — the CLI has no installer unit-test harness; covered the affected paths with direct smoke assertions instead
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR targets a feature branch, not pushed directly to `main`