### PR TITLE
fix(cli): run TypeScript fallback with Node

### DIFF
--- a/cli/scripts/build.mjs
+++ b/cli/scripts/build.mjs
@@ -4,9 +4,6 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-const isWindows = process.platform === 'win32';
-const localBin = (name) => join('node_modules', '.bin', isWindows ? `${name}.cmd` : name);
-
 function run(command, args) {
   const result = spawnSync(command, args, { stdio: 'inherit', shell: false });
   if (result.error && result.error.code === 'ENOENT') {
@@ -20,7 +17,7 @@ if (!bunResult.missing) {
   process.exit(bunResult.status);
 }
 
-const tsc = localBin('tsc');
+const tsc = join('node_modules', 'typescript', 'bin', 'tsc');
 if (!existsSync(tsc)) {
   console.error('Build failed: neither bun nor local TypeScript compiler is available.');
   console.error('Run `npm ci` first, or install Bun from https://bun.sh/docs/installation.');
@@ -28,5 +25,5 @@ if (!existsSync(tsc)) {
 }
 
 console.warn('bun not found; falling back to TypeScript compiler output.');
-const tscResult = run(tsc, []);
+const tscResult = run(process.execPath, [tsc]);
 process.exit(tscResult.status);


### PR DESCRIPTION
## What does this PR change?

Runs the TypeScript fallback through the current Node executable and TypeScript's JavaScript entry point instead of spawning the platform-specific `.bin` shim.

## Why?

On Windows without Bun, `spawnSync(..., { shell: false })` cannot launch `node_modules/.bin/tsc.cmd`. The build prints the fallback message but exits with status 1 before compiling.

## Verification

- `npm run build` on Windows without Bun — exits 0 through the TypeScript fallback
- `npm run typecheck`
- `node dist/index.js --version` — prints `2.5.0`

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — N/A; this is limited to CLI build tooling
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed — N/A; no assets changed
- [x] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`) — N/A; verified the platform-specific build path directly on Windows without Bun
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR targets a feature branch, not pushed directly to `main`