### PR TITLE
test: expect pinned shadcn CLI version

### DIFF
--- a/.claude/skills/ui-styling/scripts/tests/test_shadcn_add.py
+++ b/.claude/skills/ui-styling/scripts/tests/test_shadcn_add.py
@@ -173,7 +173,7 @@ class TestShadcnInstaller:
         # Verify correct command was called
         mock_run.assert_called_once()
         call_args = mock_run.call_args[0][0]
-        assert call_args[:3] == ["npx", "shadcn@latest", "add"]
+        assert call_args[:3] == ["npx", "shadcn@2.3.0", "add"]
         assert "button" in call_args
         assert "card" in call_args
 


### PR DESCRIPTION
## What does this PR change?

Updates the successful shadcn component installation test to expect the pinned fallback CLI version, `shadcn@2.3.0`, used by the implementation.

## Why?

`ShadcnInstaller._get_shadcn_version()` has deliberately fallen back to version 2.3.0 since commit 381f01d, but this assertion still expected `shadcn@latest`. The stale expectation causes the Tests workflow on `main` to fail.

## Validation

- `PYTHONUTF8=1 python -m pytest .claude/skills -q`
- Result: 77 passed, 34 subtests passed

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — Not applicable: this is a test-only correction.
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed — Not applicable: no assets changed.
- [x] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR targets a feature branch, not pushed directly to `main`