### PR TITLE
fix(cli): sync shadcn test asset

### DIFF
--- a/cli/assets/skills/ui-styling/scripts/tests/test_shadcn_add.py
+++ b/cli/assets/skills/ui-styling/scripts/tests/test_shadcn_add.py
@@ -173,7 +173,7 @@ class TestShadcnInstaller:
         # Verify correct command was called
         mock_run.assert_called_once()
         call_args = mock_run.call_args[0][0]
-        assert call_args[:3] == ["npx", "shadcn@latest", "add"]
+        assert call_args[:3] == ["npx", "shadcn@2.3.0", "add"]
         assert "button" in call_args
         assert "card" in call_args
 


### PR DESCRIPTION
## What does this PR change?

Synchronizes the generated CLI asset copy of `test_shadcn_add.py` with the source test updated in #432.

## Why?

#432 changed the source assertion to the pinned fallback, `shadcn@2.3.0`, but the corresponding file under `cli/assets/` still expected `shadcn@latest`. That drift causes `npm --prefix cli run check:assets` to fail on `main`.

## Validation

- `npm --prefix cli run check:assets` — Assets are in sync
- `PYTHONUTF8=1 python -m pytest .claude/skills -q` — 77 passed, 34 subtests passed

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — The source test was already updated in #432; this PR contains only its generated CLI mirror.
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed
- [x] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`) — No behavior change; this synchronizes an existing test.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR targets a feature branch, not pushed directly to `main`