### PR TITLE
feat(cli): add --global flag to uipro update and support --ai universal target (#435, #436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ uipro init --ai kilocode    # KiloCode
 uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
 uipro init --ai codewhale   # CodeWhale
+uipro init --ai universal   # Universal / Agent Standard (.agents/skills/)
 uipro init --ai all         # All assistants
 ```
 
@@ -325,6 +326,7 @@ The npm package is `ui-ux-pro-max-cli`; it still installs the `uipro` command. O
 ```bash
 uipro init --ai claude --global   # Install to ~/.claude/skills/
 uipro init --ai cursor --global   # Install to ~/.cursor/skills/
+uipro init --ai universal --global # Install to ~/.agents/skills/
 ```
 
 ### Other CLI Commands
@@ -332,6 +334,7 @@ uipro init --ai cursor --global   # Install to ~/.cursor/skills/
 ```bash
 uipro versions              # List available versions
 uipro update                # Refresh skill files from installed CLI package
+uipro update --global       # Refresh global skill files from installed CLI package
 uipro init --offline        # Compatibility flag; installs bundled templates
 uipro uninstall             # Remove skill (auto-detect platform)
 uipro uninstall --ai claude # Remove specific platform

--- a/README.zh.md
+++ b/README.zh.md
@@ -315,6 +315,7 @@ uipro init --ai kilocode    # KiloCode
 uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
 uipro init --ai codewhale   # CodeWhale
+uipro init --ai universal   # Universal / Agent Standard (.agents/skills/)
 uipro init --ai all         # 所有助手
 ```
 
@@ -325,6 +326,7 @@ npm 包名为 `ui-ux-pro-max-cli`；它仍然安装 `uipro` 命令。旧版 `uip
 ```bash
 uipro init --ai claude --global   # 安装到 ~/.claude/skills/
 uipro init --ai cursor --global   # 安装到 ~/.cursor/skills/
+uipro init --ai universal --global # 安装到 ~/.agents/skills/
 ```
 
 ### 其他 CLI 命令
@@ -332,6 +334,7 @@ uipro init --ai cursor --global   # 安装到 ~/.cursor/skills/
 ```bash
 uipro versions              # 列出可用版本
 uipro update                # 从已安装的 CLI 包刷新技能文件
+uipro update --global       # 从已安装的 CLI 包刷新全局技能文件
 uipro init --offline        # 兼容性标志；安装捆绑模板
 uipro uninstall             # 移除技能（自动检测平台）
 uipro uninstall --ai claude # 移除特定平台

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,16 +24,18 @@ uipro init --ai qoder       # Qoder
 uipro init --ai gemini      # Gemini CLI
 uipro init --ai trae        # Trae
 uipro init --ai opencode    # OpenCode
-uipro init --ai continue    # Continue (Skills)
+uipro init --ai universal   # Universal / Agent Standard (.agents/skills/)
 uipro init --ai all         # All assistants
 
 # Options
 uipro init --offline        # Compatibility flag; installs bundled templates
 uipro init --force          # Overwrite existing files
+uipro init --global         # Install globally to home directory (~/)
 
 # Other commands
 uipro versions              # List available versions
 uipro update                # Update the global CLI to the latest release
+uipro update --global       # Refresh globally installed skill files from this CLI package
 ```
 
 ## GitHub Authentication

--- a/cli/assets/templates/platforms/universal.json
+++ b/cli/assets/templates/platforms/universal.json
@@ -1,0 +1,21 @@
+{
+  "platform": "universal",
+  "displayName": "Universal / Agent Standard",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".agents",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "Comprehensive design guide for web, mobile, and desktop applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 22 technology stacks."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "ui-ux-pro-max",
+  "description": "Comprehensive design guide for web, mobile, and desktop applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 22 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,7 +20,13 @@ interface UpdateOptions {
 }
 
 async function getPackageVersion(): Promise<string> {
-  const packagePath = join(__dirname, '..', 'package.json');
+  const packageCandidates = [
+    // Bun bundle or root: dist/index.js -> ../package.json
+    join(__dirname, '..', 'package.json'),
+    // TypeScript fallback: dist/commands/update.js -> ../../package.json
+    join(__dirname, '..', '..', 'package.json'),
+  ];
+  const packagePath = packageCandidates.find(path => existsSync(path)) ?? packageCandidates[0];
   const pkg = JSON.parse(await readFile(packagePath, 'utf-8')) as { version: string };
   return pkg.version;
 }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -14,6 +14,7 @@ const CLI_PACKAGE_NAME = 'ui-ux-pro-max-cli';
 
 interface UpdateOptions {
   ai?: AIType;
+  global?: boolean;
   token?: string;
 }
 
@@ -38,6 +39,9 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
     const latestVersion = normalizeTagVersion(release.tag_name);
     spinner.succeed(`Latest version: ${chalk.cyan(release.tag_name)}`);
 
+    const aiFlag = options.ai ? ` --ai ${options.ai}` : ' --ai <platform>';
+    const globalFlag = options.global ? ' --global' : '';
+
     if (currentVersion !== latestVersion) {
       console.log();
 
@@ -46,7 +50,7 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
       if (!/^\d+\.\d+\.\d+([.-][0-9A-Za-z.-]+)?$/.test(latestVersion)) {
         logger.warn(`Installed CLI is ${chalk.cyan(currentVersion)}; latest release is ${chalk.cyan(release.tag_name)}.`);
         logger.info(`Update the CLI package: ${chalk.cyan(`npm install -g ${CLI_PACKAGE_NAME}@${latestVersion}`)}`);
-        logger.info('Then rerun: uipro init --ai <platform> --force');
+        logger.info(`Then rerun: uipro init${aiFlag} --force${globalFlag}`);
         return;
       }
 
@@ -71,7 +75,7 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
 
       console.log();
       logger.success(`Updated to ${chalk.cyan(latestVersion)}.`);
-      logger.info(`Now rerun ${chalk.cyan('uipro init --ai <platform> --force')} to refresh your skill files.`);
+      logger.info(`Now rerun ${chalk.cyan(`uipro init${aiFlag} --force${globalFlag}`)} to refresh your skill files.`);
       return;
     }
 
@@ -82,6 +86,7 @@ export async function updateCommand(options: UpdateOptions): Promise<void> {
     await initCommand({
       ai: options.ai,
       force: true,
+      global: options.global,
       token: options.token,
     });
   } catch (error) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -55,6 +55,7 @@ program
   .command('update')
   .description('Update UI/UX Pro Max to latest version')
   .option('-a, --ai <type>', `AI assistant type (${AI_TYPES.join(', ')})`)
+  .option('-g, --global', 'Update global installation in home directory (~/)')
   .option('-t, --token <token>', 'GitHub Personal Access Token for higher API rate limits')
   .action(async (options) => {
     if (options.ai && !AI_TYPES.includes(options.ai)) {
@@ -64,6 +65,7 @@ program
     }
     await updateCommand({
       ai: options.ai as AIType | undefined,
+      global: options.global,
       token: options.token,
     });
   });

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1,4 +1,4 @@
-export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'codewhale' | 'all';
+export type AIType = 'claude' | 'cursor' | 'windsurf' | 'antigravity' | 'copilot' | 'kiro' | 'roocode' | 'codex' | 'qoder' | 'gemini' | 'trae' | 'opencode' | 'continue' | 'codebuddy' | 'droid' | 'kilocode' | 'warp' | 'augment' | 'codewhale' | 'universal' | 'all';
 export type ConcreteAIType = Exclude<AIType, 'all'>;
 
 export type InstallType = 'full' | 'reference';
@@ -43,7 +43,7 @@ export interface PlatformConfig {
   skillOrWorkflow: string;
 }
 
-export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'codewhale', 'all'];
+export const AI_TYPES: AIType[] = ['claude', 'cursor', 'windsurf', 'antigravity', 'copilot', 'roocode', 'kiro', 'codex', 'qoder', 'gemini', 'trae', 'opencode', 'continue', 'codebuddy', 'droid', 'kilocode', 'warp', 'augment', 'codewhale', 'universal', 'all'];
 
 // Legacy folder mapping for backward compatibility with ZIP-based installs.
 // Note: .shared is included for platforms that used ZIP installs. Post-ZIP platforms
@@ -68,4 +68,5 @@ export const AI_FOLDERS: Record<ConcreteAIType, string[]> = {
   warp: ['.warp', '.shared'],
   augment: ['.augment', '.shared'],
   codewhale: ['.codewhale', '.shared'],
+  universal: ['.agents', '.shared'],
 };

--- a/cli/src/utils/detect.ts
+++ b/cli/src/utils/detect.ts
@@ -22,6 +22,7 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (existsSync(join(cwd, '.agents'))) {
     detected.push('antigravity');
     detected.push('codex');
+    detected.push('universal');
   } else if (existsSync(join(cwd, '.agent'))) {
     detected.push('antigravity');
   }
@@ -76,11 +77,11 @@ export function detectAIType(cwd: string = process.cwd()): DetectionResult {
   if (detected.length === 1) {
     suggested = detected[0];
   } else if (
-    detected.length === 2 &&
+    (detected.length === 2 || detected.length === 3) &&
     detected.includes('antigravity') &&
     detected.includes('codex')
   ) {
-    // Both platforms share `.agents`; avoid suggesting an install for every AI.
+    // Platforms share `.agents`; avoid suggesting an install for every AI.
     suggested = 'codex';
   } else if (detected.length > 1) {
     suggested = 'all';
@@ -129,6 +130,8 @@ export function getAITypeDescription(aiType: AIType): string {
       return 'Augment (.augment/skills/)';
     case 'codewhale':
       return 'CodeWhale (.codewhale/skills/)';
+    case 'universal':
+      return 'Universal (.agents/skills/)';
     case 'all':
       return 'All AI assistants';
   }

--- a/cli/src/utils/template.ts
+++ b/cli/src/utils/template.ts
@@ -54,6 +54,7 @@ const AI_TO_PLATFORM: Record<string, string> = {
   warp: 'warp',
   augment: 'augment',
   codewhale: 'codewhale',
+  universal: 'universal',
 };
 
 async function exists(path: string): Promise<boolean> {

--- a/src/ui-ux-pro-max/templates/platforms/universal.json
+++ b/src/ui-ux-pro-max/templates/platforms/universal.json
@@ -1,0 +1,21 @@
+{
+  "platform": "universal",
+  "displayName": "Universal / Agent Standard",
+  "installType": "full",
+  "folderStructure": {
+    "root": ".agents",
+    "skillPath": "skills/ui-ux-pro-max",
+    "filename": "SKILL.md"
+  },
+  "scriptPath": "skills/ui-ux-pro-max/scripts/search.py",
+  "frontmatter": {
+    "name": "ui-ux-pro-max",
+    "description": "Comprehensive design guide for web, mobile, and desktop applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 22 technology stacks."
+  },
+  "sections": {
+    "quickReference": false
+  },
+  "title": "ui-ux-pro-max",
+  "description": "Comprehensive design guide for web, mobile, and desktop applications. Contains 67 styles, 161 color palettes, 57 font pairings, 99 UX guidelines, and 25 chart types across 22 technology stacks. Searchable database with priority-based recommendations.",
+  "skillOrWorkflow": "Skill"
+}


### PR DESCRIPTION
### Description

This PR resolves issues #435 and #436:

1. **Fixes #435**: Adds \-g, --global\ flag support to \uipro update\, enabling users to update global installations in \~/\ directly without manual uninstall/re-init cycles.
2. **Fixes #436**: Adds \--ai universal\ target support for installing skills into \.agents/skills/\ (and \~/.agents/skills/\ with \--global\), following standard agent skill conventions (OpenCode, Vercel Skills CLI, Antigravity, etc.).

### References
- Issue #435: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/issues/435
- Issue #436: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/issues/436