### PR TITLE
fix: bump skill.json version to 2.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "UI/UX design intelligence skill with 84 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stack guidelines",
-    "version": "2.11.0"
+    "version": "2.13.0"
   },
   "plugins": [
     {
       "name": "ui-ux-pro-max",
       "source": "./",
       "description": "Professional UI/UX design intelligence for AI coding assistants. Includes searchable databases of styles, colors, typography, charts, and UX guidelines for React, Next.js, Astro, Vue, Nuxt.js, Nuxt UI, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, and Three.js.",
-      "version": "2.11.0",
+      "version": "2.13.0",
       "author": {
         "name": "nextlevelbuilder"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-ux-pro-max",
   "description": "UI/UX design intelligence. Searchable local database with 84 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stacks (React, Next.js, Vue, Nuxt.js, Nuxt UI, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, WPF, WinUI, Avalonia, Uno Platform, UWP, Three.js). Use when designing, building, or reviewing UI: pages, components, color schemes, typography, layout, accessibility, animation, or data visualization.",
-  "version": "2.11.0",
+  "version": "2.13.0",
   "author": {
     "name": "nextlevelbuilder"
   },

--- a/skill.json
+++ b/skill.json
@@ -2,7 +2,7 @@
   "name": "ui-ux-pro-max",
   "displayName": "UI/UX Pro Max",
   "description": "AI-powered design intelligence with 84 UI styles, 192 color palettes, 74 font pairings, 98 UX guidelines, and 25 chart types across 22 tech stacks.",
-  "version": "2.11.0",
+  "version": "2.13.0",
   "author": "NextLevelBuilder",
   "license": "MIT",
   "homepage": "https://uupm.cc",


### PR DESCRIPTION
## Summary

- Bumps `skill.json`, `marketplace.json`, and `plugin.json` version from `2.11.0` to `2.13.0` to match the latest GitHub release

## Why

The latest release tag is `v2.13.0`, but these files still declared version `2.11.0`. This causes `claude plugins update` to report "already at latest version (2.11.0)" even though a newer version exists.