### PR TITLE
docs: clarify Claude ZIP upload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,23 @@ rm -rf .windsurf/skills/ui-ux-pro-max # Windsurf
 rm -rf .agents/skills/ui-ux-pro-max   # Antigravity / Codex
 ```
 
+### Claude.ai's "Upload a skill" dialog says "Zip contains too many files (maximum 200)"
+
+Do not upload the full GitHub repository ZIP. It is a development checkout that includes source code, CLI assets, documentation, previews, and multiple bundled skills, so it exceeds Claude's 200-file upload limit. It is not a Claude skill upload artifact, and this project does not currently publish a separate manual-upload ZIP for Claude.ai.
+
+For Claude Code, install through the Marketplace:
+
+```bash
+/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill
+/plugin install ui-ux-pro-max@ui-ux-pro-max-skill
+```
+
+Or use the CLI installer:
+
+```bash
+npx ui-ux-pro-max-cli init --ai claude
+```
+
 ### Claude Marketplace install fails with "Zip file contains a symbolic link"
 
 This is a known issue with versions prior to v2.5.1. The repository used symlinks internally which some installation tools can't handle. **Fix:** use the CLI installer instead:

--- a/README.zh.md
+++ b/README.zh.md
@@ -578,6 +578,23 @@ rm -rf .windsurf/skills/ui-ux-pro-max # Windsurf
 rm -rf .agents/skills/ui-ux-pro-max   # Antigravity / Codex
 ```
 
+### Claude.ai 的“上传技能”对话框提示 "Zip contains too many files (maximum 200)"
+
+请勿上传完整的 GitHub 仓库 ZIP。该 ZIP 是开发用的代码仓库，包含源代码、CLI 资源、文档、预览以及多个打包的技能，因此会超出 Claude 的 200 个文件上传限制。它不是用于上传到 Claude 的技能安装包，并且本项目目前不提供用于手动上传到 Claude.ai 的单独 ZIP。
+
+对于 Claude Code，请通过 Marketplace 安装：
+
+```bash
+/plugin marketplace add nextlevelbuilder/ui-ux-pro-max-skill
+/plugin install ui-ux-pro-max@ui-ux-pro-max-skill
+```
+
+也可以使用 CLI 安装器：
+
+```bash
+npx ui-ux-pro-max-cli init --ai claude
+```
+
 ### Claude Marketplace 安装失败，提示 "Zip file contains a symbolic link"
 
 这是 v2.5.1 之前版本的已知问题。仓库内部使用了符号链接，某些安装工具无法处理。**解决办法：** 改用 CLI 安装器：


### PR DESCRIPTION
## Summary
- explain that the full repository archive is not a Claude.ai skill upload artifact
- direct Claude Code users to the supported Marketplace and CLI installation paths
- keep English and Chinese troubleshooting guidance aligned

Closes #235

## Validation
- `git diff --check`
- verified Marketplace identifiers against `.claude-plugin/marketplace.json`
- verified CLI command against the existing installation documentation
- independent docs review: PASS

Gherkin impact: none