### PR TITLE
docs: fix outdated manual sync steps in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,10 +99,8 @@ git checkout -b feat/your-feature-name
 
 # 2. Make your changes in src/ui-ux-pro-max/
 
-# 3. Sync changes to CLI assets
-cp -r src/ui-ux-pro-max/data/* cli/assets/data/
-cp -r src/ui-ux-pro-max/scripts/* cli/assets/scripts/
-cp -r src/ui-ux-pro-max/templates/* cli/assets/templates/
+# 3. Sync changes to CLI assets and the Claude Code skill
+cd cli && npm run sync:assets && cd ..
 
 # 4. Build and test the CLI locally
 cd cli && bun run build


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md's manual `cp -r` sync steps only copy files into `cli/assets/`, but the actual sync tooling (`cli/scripts/sync-assets.mjs`, documented in `CLAUDE.md`) also mirrors `data/` and `scripts/` into `.claude/skills/ui-ux-pro-max/`.
- Following the manual steps as written leaves that second mirror stale and would fail the "Check asset sync" CI check.
- Replaced the manual `cp` commands with `cd cli && npm run sync:assets && cd ..`, matching the command already documented in CLAUDE.md.

## Test plan
- [x] Confirmed `sync:assets` is a real npm script in `cli/package.json`
- [x] Confirmed `sync-assets.mjs` mirrors into both `cli/assets/` and `.claude/skills/ui-ux-pro-max/`
- Docs-only change, no code behavior affected