### PR TITLE
test(cli): add droid to script-path rendering coverage

### DIFF
--- a/cli/tests/e2e/template-script-paths.spec.ts
+++ b/cli/tests/e2e/template-script-paths.spec.ts
@@ -6,6 +6,7 @@ const cases = [
   ['codex', '.agents/skills/ui-ux-pro-max/scripts/search.py'],
   ['copilot', '.github/prompts/ui-ux-pro-max/scripts/search.py'],
   ['kiro', '.kiro/steering/ui-ux-pro-max/scripts/search.py'],
+  ['droid', '.factory/skills/ui-ux-pro-max/scripts/search.py'],
 ] as const;
 const SEARCH_COMMAND_COUNT = 17;
 


### PR DESCRIPTION
## Summary
- `cli/tests/e2e/template-script-paths.spec.ts` currently checks generated search-script paths for only 4 of the ~20 supported `--ai` platforms (`claude`, `codex`, `copilot`, `kiro`).
- Adds `droid` to the covered cases. Like `codex` (root `.agents`), `droid`'s install root (`.factory`) doesn't match its platform identifier (`droid`), which is exactly the kind of naming mismatch a future refactor of `cli/src/utils/template.ts` or `cli/assets/templates/platforms/droid.json` could silently break without a test catching it.
- No behavior change — this only extends existing test coverage using the file's existing pattern.

## Test plan
- [x] Verified the expected path (`.factory/skills/ui-ux-pro-max/scripts/search.py`) by tracing `cli/assets/templates/platforms/droid.json` (`root: .factory`, `scriptPath: skills/ui-ux-pro-max/scripts/search.py`) against `renderSkillFile`'s `rootedScriptPath` logic in `cli/src/utils/template.ts`.
- [x] Confirmed `droid.json`'s `installType`/`sections` config matches the already-passing `copilot`/`kiro` cases (`installType: full`, `quickReference: false`), so the shared `SEARCH_COMMAND_COUNT` assertion should hold.
- [ ] Could not run the Playwright suite locally (no Node/npm/bun available in this environment) — please let CI confirm.