### PR TITLE
fix(design-system): make the skill work outside a vendored checkout and on Windows

### DIFF
--- a/.claude/skills/design-system/scripts/embed-tokens.cjs
+++ b/.claude/skills/design-system/scripts/embed-tokens.cjs
@@ -15,12 +15,16 @@ const path = require('path');
 
 // Find project root (look for assets/design-tokens.css)
 function findProjectRoot(startDir) {
+  // Walk up until dirname stops changing: on Windows the root is 'C:\', so a
+  // `dir !== '/'` guard never terminates.
   let dir = startDir;
-  while (dir !== '/') {
+  for (;;) {
     if (fs.existsSync(path.join(dir, 'assets', 'design-tokens.css'))) {
       return dir;
     }
-    dir = path.dirname(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return null;
 }

--- a/.claude/skills/design-system/scripts/fetch-background.py
+++ b/.claude/skills/design-system/scripts/fetch-background.py
@@ -9,10 +9,32 @@ import json
 import csv
 import re
 import sys
+import os
 from pathlib import Path
 
-# Project root relative to this script
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+# The skill can be installed outside the project it operates on (user-level
+# ~/.claude/skills/, or as a plugin), so the project root cannot be derived from
+# this file's location. Resolve it from the working directory instead -- the same
+# convention generate-tokens.cjs and validate-tokens.cjs already use via
+# process.cwd(). DESIGN_SYSTEM_PROJECT_ROOT overrides it explicitly.
+def _find_project_root():
+    override = os.environ.get('DESIGN_SYSTEM_PROJECT_ROOT')
+    if override:
+        return Path(override).resolve()
+    start = Path.cwd().resolve()
+    markers = (
+        Path('assets') / 'design-tokens.json',
+        Path('assets') / 'design-tokens.css',
+        Path('package.json'),
+        Path('.git'),
+    )
+    for candidate in (start, *start.parents):
+        if any((candidate / marker).exists() for marker in markers):
+            return candidate
+    return start
+
+
+PROJECT_ROOT = _find_project_root()
 TOKENS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 BACKGROUNDS_CSV = Path(__file__).parent.parent / 'data' / 'slide-backgrounds.csv'
 

--- a/.claude/skills/design-system/scripts/html-token-validator.py
+++ b/.claude/skills/design-system/scripts/html-token-validator.py
@@ -42,6 +42,16 @@ def _find_project_root():
 
 
 PROJECT_ROOT = _find_project_root()
+
+# Force UTF-8 on stdout/stderr: this script prints emoji, which raises
+# UnicodeEncodeError on a Windows console (cp1252). Same guard as
+# src/ui-ux-pro-max/scripts/search.py.
+import io
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 TOKENS_JSON_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 TOKENS_CSS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.css'
 

--- a/.claude/skills/design-system/scripts/html-token-validator.py
+++ b/.claude/skills/design-system/scripts/html-token-validator.py
@@ -15,11 +15,33 @@ Usage:
 import re
 import json
 import sys
+import os
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
-# Project root relative to this script
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+# The skill can be installed outside the project it operates on (user-level
+# ~/.claude/skills/, or as a plugin), so the project root cannot be derived from
+# this file's location. Resolve it from the working directory instead -- the same
+# convention generate-tokens.cjs and validate-tokens.cjs already use via
+# process.cwd(). DESIGN_SYSTEM_PROJECT_ROOT overrides it explicitly.
+def _find_project_root():
+    override = os.environ.get('DESIGN_SYSTEM_PROJECT_ROOT')
+    if override:
+        return Path(override).resolve()
+    start = Path.cwd().resolve()
+    markers = (
+        Path('assets') / 'design-tokens.json',
+        Path('assets') / 'design-tokens.css',
+        Path('package.json'),
+        Path('.git'),
+    )
+    for candidate in (start, *start.parents):
+        if any((candidate / marker).exists() for marker in markers):
+            return candidate
+    return start
+
+
+PROJECT_ROOT = _find_project_root()
 TOKENS_JSON_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 TOKENS_CSS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.css'
 

--- a/.claude/skills/design-system/scripts/search-slides.py
+++ b/.claude/skills/design-system/scripts/search-slides.py
@@ -13,6 +13,16 @@ from slide_search_core import (
     get_color_for_emotion, get_background_config
 )
 
+# Force UTF-8 on stdout/stderr: this script prints emoji, which raises
+# UnicodeEncodeError on a Windows console (cp1252). Same guard as
+# src/ui-ux-pro-max/scripts/search.py.
+import io
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
 
 def format_result(result, domain):
     """Format a single search result for display"""

--- a/.claude/skills/design-system/scripts/tests/test_validate_tokens.py
+++ b/.claude/skills/design-system/scripts/tests/test_validate_tokens.py
@@ -20,11 +20,15 @@ def _run(tmp_path: Path, css: str) -> subprocess.CompletedProcess:
     node = shutil.which("node")
     if not node:
         pytest.skip("node not available")
-    (tmp_path / "sample.css").write_text(css)
+    (tmp_path / "sample.css").write_text(css, encoding="utf-8")
     return subprocess.run(
         [node, str(SCRIPT), "--dir", str(tmp_path)],
         capture_output=True,
         text=True,
+        # validate-tokens.cjs prints emoji; without an explicit encoding Python
+        # decodes the pipe with the locale codec (cp1252 on Windows), which
+        # raises in the reader thread and leaves result.stdout set to None.
+        encoding="utf-8",
     )
 
 

--- a/cli/assets/skills/design-system/scripts/embed-tokens.cjs
+++ b/cli/assets/skills/design-system/scripts/embed-tokens.cjs
@@ -15,12 +15,16 @@ const path = require('path');
 
 // Find project root (look for assets/design-tokens.css)
 function findProjectRoot(startDir) {
+  // Walk up until dirname stops changing: on Windows the root is 'C:\', so a
+  // `dir !== '/'` guard never terminates.
   let dir = startDir;
-  while (dir !== '/') {
+  for (;;) {
     if (fs.existsSync(path.join(dir, 'assets', 'design-tokens.css'))) {
       return dir;
     }
-    dir = path.dirname(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return null;
 }

--- a/cli/assets/skills/design-system/scripts/fetch-background.py
+++ b/cli/assets/skills/design-system/scripts/fetch-background.py
@@ -9,10 +9,32 @@ import json
 import csv
 import re
 import sys
+import os
 from pathlib import Path
 
-# Project root relative to this script
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+# The skill can be installed outside the project it operates on (user-level
+# ~/.claude/skills/, or as a plugin), so the project root cannot be derived from
+# this file's location. Resolve it from the working directory instead -- the same
+# convention generate-tokens.cjs and validate-tokens.cjs already use via
+# process.cwd(). DESIGN_SYSTEM_PROJECT_ROOT overrides it explicitly.
+def _find_project_root():
+    override = os.environ.get('DESIGN_SYSTEM_PROJECT_ROOT')
+    if override:
+        return Path(override).resolve()
+    start = Path.cwd().resolve()
+    markers = (
+        Path('assets') / 'design-tokens.json',
+        Path('assets') / 'design-tokens.css',
+        Path('package.json'),
+        Path('.git'),
+    )
+    for candidate in (start, *start.parents):
+        if any((candidate / marker).exists() for marker in markers):
+            return candidate
+    return start
+
+
+PROJECT_ROOT = _find_project_root()
 TOKENS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 BACKGROUNDS_CSV = Path(__file__).parent.parent / 'data' / 'slide-backgrounds.csv'
 

--- a/cli/assets/skills/design-system/scripts/html-token-validator.py
+++ b/cli/assets/skills/design-system/scripts/html-token-validator.py
@@ -42,6 +42,16 @@ def _find_project_root():
 
 
 PROJECT_ROOT = _find_project_root()
+
+# Force UTF-8 on stdout/stderr: this script prints emoji, which raises
+# UnicodeEncodeError on a Windows console (cp1252). Same guard as
+# src/ui-ux-pro-max/scripts/search.py.
+import io
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 TOKENS_JSON_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 TOKENS_CSS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.css'
 

--- a/cli/assets/skills/design-system/scripts/html-token-validator.py
+++ b/cli/assets/skills/design-system/scripts/html-token-validator.py
@@ -15,11 +15,33 @@ Usage:
 import re
 import json
 import sys
+import os
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
-# Project root relative to this script
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
+# The skill can be installed outside the project it operates on (user-level
+# ~/.claude/skills/, or as a plugin), so the project root cannot be derived from
+# this file's location. Resolve it from the working directory instead -- the same
+# convention generate-tokens.cjs and validate-tokens.cjs already use via
+# process.cwd(). DESIGN_SYSTEM_PROJECT_ROOT overrides it explicitly.
+def _find_project_root():
+    override = os.environ.get('DESIGN_SYSTEM_PROJECT_ROOT')
+    if override:
+        return Path(override).resolve()
+    start = Path.cwd().resolve()
+    markers = (
+        Path('assets') / 'design-tokens.json',
+        Path('assets') / 'design-tokens.css',
+        Path('package.json'),
+        Path('.git'),
+    )
+    for candidate in (start, *start.parents):
+        if any((candidate / marker).exists() for marker in markers):
+            return candidate
+    return start
+
+
+PROJECT_ROOT = _find_project_root()
 TOKENS_JSON_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.json'
 TOKENS_CSS_PATH = PROJECT_ROOT / 'assets' / 'design-tokens.css'
 

--- a/cli/assets/skills/design-system/scripts/search-slides.py
+++ b/cli/assets/skills/design-system/scripts/search-slides.py
@@ -13,6 +13,16 @@ from slide_search_core import (
     get_color_for_emotion, get_background_config
 )
 
+# Force UTF-8 on stdout/stderr: this script prints emoji, which raises
+# UnicodeEncodeError on a Windows console (cp1252). Same guard as
+# src/ui-ux-pro-max/scripts/search.py.
+import io
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
 
 def format_result(result, domain):
     """Format a single search result for display"""

--- a/cli/assets/skills/design-system/scripts/tests/test_validate_tokens.py
+++ b/cli/assets/skills/design-system/scripts/tests/test_validate_tokens.py
@@ -20,11 +20,15 @@ def _run(tmp_path: Path, css: str) -> subprocess.CompletedProcess:
     node = shutil.which("node")
     if not node:
         pytest.skip("node not available")
-    (tmp_path / "sample.css").write_text(css)
+    (tmp_path / "sample.css").write_text(css, encoding="utf-8")
     return subprocess.run(
         [node, str(SCRIPT), "--dir", str(tmp_path)],
         capture_output=True,
         text=True,
+        # validate-tokens.cjs prints emoji; without an explicit encoding Python
+        # decodes the pipe with the locale codec (cp1252 on Windows), which
+        # raises in the reader thread and leaves result.stdout set to None.
+        encoding="utf-8",
     )
 
 


### PR DESCRIPTION
## What does this PR change?

Makes the `design-system` skill work when it is installed outside the project it operates on, and on Windows. Four commits, one defect each, no behaviour change on macOS/Linux inside a vendored checkout.

## Why?

Closes #459.

| Commit | Defect |
|---|---|
| `fix: resolve project root from cwd, not __file__` | `PROJECT_ROOT` used five `.parent` hops, which only reach the project root when the skill sits at `<project>/.claude/skills/design-system/scripts/`. Installed at user level or as a plugin, it pointed outside the project and both scripts silently validated against no tokens. |
| `fix: stop findProjectRoot from hanging on Windows` | `while (dir !== '/')` never terminates on Windows (root is `C:\`, and `path.dirname('C:\')` is stable) — the process spins at 100% CPU instead of erroring out. |
| `fix: force UTF-8 stdout ... on cp1252 consoles` | `search-slides.py --context` and `html-token-validator.py` print emoji; on a Windows console that is an immediate `UnicodeEncodeError`. This took out `--context`, the entry point of the contextual slide system. |
| `test: decode subprocess output as UTF-8` | Found while running your suite: `test_validate_tokens.py` passes `text=True` with no `encoding`, so on Windows the validator's emoji output fails to decode, `result.stdout` is `None`, and the test dies with a `TypeError`. The suite could not pass on Windows at all. The validator itself was never at fault. |

Each fix reuses a convention this repo already has: `process.cwd()` (as in `generate-tokens.cjs` / `validate-tokens.cjs`) and the UTF-8 stdout guard from `src/ui-ux-pro-max/scripts/search.py`.

## Checklist

- [x] Changes were made in the source of truth, not directly in a mirror — for sub-skills that is `.claude/skills/`, per `cli/scripts/sync-assets.mjs:26-28`. (The template's `src/ui-ux-pro-max/` wording does not apply: `design-system` has no `src/` copy.)
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` — `cli/assets/skills/design-system/` is included in each commit, and `check:assets` reports **Assets are in sync**.
- [x] Tests: `test_validate_tokens.py` goes from 1 failed / 1 passed to **2 passed**, in both copies. No new test was needed for the other three — defect 2 and 3 are reproduced by the commands in #459.
- [x] Commit messages follow Conventional Commits.
- [x] Targets a feature branch.

## Verified on

Windows 11 / Python 3.14.0 / Node 24.11.1. After the patches the whole script surface runs green from a project root: `generate-tokens.cjs` (96 CSS variables from `design-tokens-starter.json`), `validate-tokens.cjs` (flags a hardcoded hex), `search-slides.py` (plain, `-d chart`, `--context`), `html-token-validator.py`, `slide-token-validator.py`, `fetch-background.py`, and `embed-tokens.cjs` both inside and outside a project — clean error instead of the hang.

## Two things left alone, deliberately

1. `brand/scripts/tests/test_sync_brand_to_tokens.py` has the same `text=True`-without-`encoding` pattern and is one emoji away from the same failure. Out of scope here — happy to send a follow-up.
2. `.github/workflows/check-asset-sync.yml` filters on `src/ui-ux-pro-max/**`, `cli/assets/**` and `.claude/skills/ui-ux-pro-max/**`, but not `.claude/skills/<sub-skill>/**`. A PR editing only a sub-skill's source of truth never runs `check:assets`. Adding `.claude/skills/**` would close that gap; say the word and I will include it.

Defect 1 is implemented as a cwd walk-up with a `DESIGN_SYSTEM_PROJECT_ROOT` override. If you would rather have a `${CLAUDE_PLUGIN_ROOT}`-style convention consistent with `ui-ux-pro-max`, I will rework that commit.
