### PR TITLE
test(brand): decode subprocess output as UTF-8 so the suite can pass on Windows

### DIFF
--- a/.claude/skills/brand/scripts/tests/test_sync_brand_to_tokens.py
+++ b/.claude/skills/brand/scripts/tests/test_sync_brand_to_tokens.py
@@ -24,22 +24,33 @@ TOKENS_STARTER = (
 )
 
 
-def test_sync_parses_bundled_starter_template(tmp_path):
+def _run(tmp_path: Path) -> subprocess.CompletedProcess:
     node = shutil.which("node")
     if not node:
         pytest.skip("node not available")
+    return subprocess.run(
+        [node, str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        # sync-brand-to-tokens.cjs prints emoji. Without an explicit encoding,
+        # `text=True` decodes the pipe with the locale codec, and several of
+        # those emoji have UTF-8 bytes that cp1252 has no character for
+        # (0x8F in the warning, 0x9D in the error, 0x8F in the dry-run notice).
+        # Decoding then raises inside subprocess's reader thread, the stream
+        # comes back as None, and assertions against it fail with a TypeError
+        # that hides the real result.
+        encoding="utf-8",
+    )
 
+
+def test_sync_parses_bundled_starter_template(tmp_path):
     (tmp_path / "docs").mkdir()
     (tmp_path / "assets").mkdir()
     shutil.copy(BRAND_STARTER, tmp_path / "docs" / "brand-guidelines.md")
     shutil.copy(TOKENS_STARTER, tmp_path / "assets" / "design-tokens.json")
 
-    result = subprocess.run(
-        [node, str(SCRIPT)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(tmp_path)
 
     # Must not crash (the bug raised an unhandled TypeError).
     assert "TypeError" not in result.stderr, result.stderr
@@ -50,3 +61,20 @@ def test_sync_parses_bundled_starter_template(tmp_path):
     assert primitive["primary"]["500"]["$value"] == "#2563EB"
     assert primitive["secondary"]["500"]["$value"] == "#8B5CF6"
     assert primitive["accent"]["500"]["$value"] == "#10B981"
+
+
+def test_reports_missing_guidelines_without_breaking_the_harness(tmp_path):
+    """The missing-guidelines path is the one that breaks a locale-decoded pipe.
+
+    It is also the default state of any project that has not run the brand skill
+    yet, so it is the path a contributor hits first. The script prints its error
+    with a leading emoji whose UTF-8 encoding contains 0x9D; cp1252 has no
+    character there, so on Windows this test fails with
+    ``TypeError: argument of type 'NoneType' is not a container`` unless the
+    subprocess pipe is pinned to UTF-8.
+    """
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert result.stderr is not None
+    assert "Brand guidelines not found" in result.stderr

--- a/cli/assets/skills/brand/scripts/tests/test_sync_brand_to_tokens.py
+++ b/cli/assets/skills/brand/scripts/tests/test_sync_brand_to_tokens.py
@@ -24,22 +24,33 @@ TOKENS_STARTER = (
 )
 
 
-def test_sync_parses_bundled_starter_template(tmp_path):
+def _run(tmp_path: Path) -> subprocess.CompletedProcess:
     node = shutil.which("node")
     if not node:
         pytest.skip("node not available")
+    return subprocess.run(
+        [node, str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        # sync-brand-to-tokens.cjs prints emoji. Without an explicit encoding,
+        # `text=True` decodes the pipe with the locale codec, and several of
+        # those emoji have UTF-8 bytes that cp1252 has no character for
+        # (0x8F in the warning, 0x9D in the error, 0x8F in the dry-run notice).
+        # Decoding then raises inside subprocess's reader thread, the stream
+        # comes back as None, and assertions against it fail with a TypeError
+        # that hides the real result.
+        encoding="utf-8",
+    )
 
+
+def test_sync_parses_bundled_starter_template(tmp_path):
     (tmp_path / "docs").mkdir()
     (tmp_path / "assets").mkdir()
     shutil.copy(BRAND_STARTER, tmp_path / "docs" / "brand-guidelines.md")
     shutil.copy(TOKENS_STARTER, tmp_path / "assets" / "design-tokens.json")
 
-    result = subprocess.run(
-        [node, str(SCRIPT)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run(tmp_path)
 
     # Must not crash (the bug raised an unhandled TypeError).
     assert "TypeError" not in result.stderr, result.stderr
@@ -50,3 +61,20 @@ def test_sync_parses_bundled_starter_template(tmp_path):
     assert primitive["primary"]["500"]["$value"] == "#2563EB"
     assert primitive["secondary"]["500"]["$value"] == "#8B5CF6"
     assert primitive["accent"]["500"]["$value"] == "#10B981"
+
+
+def test_reports_missing_guidelines_without_breaking_the_harness(tmp_path):
+    """The missing-guidelines path is the one that breaks a locale-decoded pipe.
+
+    It is also the default state of any project that has not run the brand skill
+    yet, so it is the path a contributor hits first. The script prints its error
+    with a leading emoji whose UTF-8 encoding contains 0x9D; cp1252 has no
+    character there, so on Windows this test fails with
+    ``TypeError: argument of type 'NoneType' is not a container`` unless the
+    subprocess pipe is pinned to UTF-8.
+    """
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert result.stderr is not None
+    assert "Brand guidelines not found" in result.stderr


### PR DESCRIPTION
## What does this PR change?

Pins the subprocess pipe in `brand/scripts/tests/test_sync_brand_to_tokens.py` to UTF-8, and adds a regression test for the code path that exposes the problem. One commit, tests only — no change to `sync-brand-to-tokens.cjs` itself.

## Why?

This is the follow-up promised in #460 (which fixes the same class of bug in `design-system`). The test does:

```python
subprocess.run([node, str(SCRIPT)], cwd=tmp_path, capture_output=True, text=True)
```

`text=True` with no `encoding` decodes the pipe with the locale codec. Three of the script's messages carry emoji whose UTF-8 bytes land on cp1252's five undefined slots:

| Line | Message | Byte |
|---|---|---|
| `sync-brand-to-tokens.cjs:132` | `⚠️  No base hex found for … color` | `0x8F` |
| `sync-brand-to-tokens.cjs:198` | `❌ Brand guidelines not found: …` | `0x9D` |
| `sync-brand-to-tokens.cjs:223` | `⏭️  Dry run - no files changed` | `0x8F` |

Decoding raises inside subprocess's reader thread, the stream comes back as `None`, and the test's own `assert "TypeError" not in result.stderr` then fails with — of all things — a `TypeError`.

Reproduced on Windows 11 / Python 3.14 / Node 24.11.1, running the script with no `docs/brand-guidelines.md` present:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1
    stdout = 'ðŸ”„ Syncing brand guidelines â†’ design tokens\n\n'   # mojibake
    stderr = None
    assert "TypeError" not in result.stderr
      -> TypeError: argument of type 'NoneType' is not a container or iterable
```

With `encoding="utf-8"`, `stderr` reads back correctly as `❌ Brand guidelines not found: …` and the assertion passes.

**The existing test survives today only by luck** — the bundled starter fixture takes none of those three paths. Emoji whose bytes miss the five cp1252 holes (`🔄`, `✅`, `📊`, `📋`, `✨`) decode as mojibake without raising, so the failure looks arbitrary until you line the bytes up.

## What the new test covers

`test_reports_missing_guidelines_without_breaking_the_harness` runs the script against an empty project — the default state of anything that has not run the brand skill yet, and the path a contributor hits first. It asserts a clean exit 1 with a readable error.

Verified it is a real regression test, not decoration: with the `encoding="utf-8"` line removed it fails on `assert result.stderr is not None`; with it, both tests pass. Confirmed in `.claude/skills/brand/` and the `cli/assets/` mirror.

## Checklist

- [x] Changes were made in the source of truth — `.claude/skills/` for sub-skills, per `cli/scripts/sync-assets.mjs:26-28`. (The template's `src/ui-ux-pro-max/` wording does not apply: `brand` has no `src/` copy.)
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` — mirror included in the commit, **Assets are in sync**.
- [x] Added a test: 1 passed → **2 passed**, in both copies.
- [x] Commit message follows Conventional Commits.
- [x] Targets a feature branch.

Independent of #460 — either can merge first, they touch different files.
