### PR TITLE
docs: document the project-slug level in the design-system tree

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -384,7 +384,7 @@ python3 .claude/skills/ui-ux-pro-max/scripts/search.py "enterprise tableview den
 세션 간 **계층적 검색**을 위해 디자인 시스템을 파일로 저장하세요.
 
 ```bash
-# 디자인 시스템을 생성하여 design-system/MASTER.md에 저장
+# 디자인 시스템을 생성하여 design-system/myapp/MASTER.md에 저장
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
 
 # 페이지별 오버라이드 파일도 생성
@@ -395,20 +395,21 @@ python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design
 
 ```
 design-system/
-├── MASTER.md           # 전역 단일 정보 출처(색상, 타이포그래피, 간격, 컴포넌트)
-└── pages/
-    └── dashboard.md    # 페이지별 오버라이드(마스터와 다른 내용만 기록)
+└── myapp/                  # 프로젝트마다 폴더 하나(-p "MyApp"의 슬러그)
+    ├── MASTER.md           # 전역 단일 정보 출처(색상, 타이포그래피, 간격, 컴포넌트)
+    └── pages/
+        └── dashboard.md    # 페이지별 오버라이드(마스터와 다른 내용만 기록)
 ```
 
 **계층적 검색 방식:**
-1. 특정 페이지(예: "결제")를 만들 때 먼저 `design-system/pages/checkout.md`를 확인합니다.
+1. 특정 페이지(예: "결제")를 만들 때 먼저 `design-system/[project-slug]/pages/checkout.md`를 확인합니다.
 2. 페이지 파일이 있으면 해당 규칙이 마스터 파일을 **재정의**합니다.
-3. 없으면 `design-system/MASTER.md`만 사용합니다.
+3. 없으면 `design-system/[project-slug]/MASTER.md`만 사용합니다.
 
 **컨텍스트 인식 검색 프롬프트:**
 ```
-[페이지 이름] 페이지를 만들고 있습니다. design-system/MASTER.md를 읽어 주세요.
-design-system/pages/[page-name].md 파일이 있는지도 확인해 주세요.
+[페이지 이름] 페이지를 만들고 있습니다. design-system/[project-slug]/MASTER.md를 읽어 주세요.
+design-system/[project-slug]/pages/[page-name].md 파일이 있는지도 확인해 주세요.
 페이지 파일이 있으면 해당 규칙을 우선 적용하세요.
 없으면 마스터 규칙만 사용하세요.
 이제 코드를 생성해 주세요...

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ results instead of mixing framework generations.
 Save your design system to files for **hierarchical retrieval across sessions**:
 
 ```bash
-# Generate and persist to design-system/MASTER.md
+# Generate and persist to design-system/myapp/MASTER.md
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
 
 # Also create a page-specific override file
@@ -417,20 +417,21 @@ This creates a `design-system/` folder structure:
 
 ```
 design-system/
-├── MASTER.md           # Global Source of Truth (colors, typography, spacing, components)
-└── pages/
-    └── dashboard.md    # Page-specific overrides (only deviations from Master)
+└── myapp/                  # One folder per project (slug of -p "MyApp")
+    ├── MASTER.md           # Global Source of Truth (colors, typography, spacing, components)
+    └── pages/
+        └── dashboard.md    # Page-specific overrides (only deviations from Master)
 ```
 
 **How hierarchical retrieval works:**
-1. When building a specific page (e.g., "Checkout"), first check `design-system/pages/checkout.md`
+1. When building a specific page (e.g., "Checkout"), first check `design-system/[project-slug]/pages/checkout.md`
 2. If the page file exists, its rules **override** the Master file
-3. If not, use `design-system/MASTER.md` exclusively
+3. If not, use `design-system/[project-slug]/MASTER.md` exclusively
 
 **Context-aware retrieval prompt:**
 ```
-I am building the [Page Name] page. Please read design-system/MASTER.md.
-Also check if design-system/pages/[page-name].md exists.
+I am building the [Page Name] page. Please read design-system/[project-slug]/MASTER.md.
+Also check if design-system/[project-slug]/pages/[page-name].md exists.
 If the page file exists, prioritize its rules.
 If not, use the Master rules exclusively.
 Now, generate the code...

--- a/README.vi.md
+++ b/README.vi.md
@@ -395,7 +395,7 @@ Tìm kiếm cho web stack có nhận biết phiên bản. Truy vấn không nêu
 Lưu hệ thống thiết kế vào tệp để **truy xuất phân cấp giữa các phiên làm việc**:
 
 ```bash
-# Tạo và lưu vào design-system/MASTER.md
+# Tạo và lưu vào design-system/myapp/MASTER.md
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
 
 # Đồng thời tạo tệp ghi đè riêng cho một trang
@@ -406,22 +406,23 @@ Lệnh trên tạo cấu trúc thư mục `design-system/`:
 
 ```
 design-system/
-├── MASTER.md           # Nguồn tham chiếu chung (màu sắc, kiểu chữ, khoảng cách, thành phần)
-└── pages/
-    └── dashboard.md    # Ghi đè riêng cho trang (chỉ những điểm khác với Master)
+└── myapp/                  # Mỗi dự án một thư mục (slug của -p "MyApp")
+    ├── MASTER.md           # Nguồn tham chiếu chung (màu sắc, kiểu chữ, khoảng cách, thành phần)
+    └── pages/
+        └── dashboard.md    # Ghi đè riêng cho trang (chỉ những điểm khác với Master)
 ```
 
 **Cách truy xuất phân cấp hoạt động:**
 
-1. Khi xây dựng một trang cụ thể (ví dụ: "Checkout"), trước tiên kiểm tra `design-system/pages/checkout.md`
+1. Khi xây dựng một trang cụ thể (ví dụ: "Checkout"), trước tiên kiểm tra `design-system/[project-slug]/pages/checkout.md`
 2. Nếu tệp của trang tồn tại, các quy tắc trong đó sẽ **ghi đè** tệp Master
-3. Nếu không, chỉ sử dụng `design-system/MASTER.md`
+3. Nếu không, chỉ sử dụng `design-system/[project-slug]/MASTER.md`
 
 **Prompt truy xuất theo ngữ cảnh:**
 
 ```
-Tôi đang xây dựng trang [Tên trang]. Hãy đọc design-system/MASTER.md.
-Đồng thời kiểm tra xem design-system/pages/[page-name].md có tồn tại hay không.
+Tôi đang xây dựng trang [Tên trang]. Hãy đọc design-system/[project-slug]/MASTER.md.
+Đồng thời kiểm tra xem design-system/[project-slug]/pages/[page-name].md có tồn tại hay không.
 Nếu tệp của trang tồn tại, hãy ưu tiên các quy tắc trong đó.
 Nếu không, chỉ sử dụng các quy tắc trong tệp Master.
 Bây giờ, hãy tạo mã nguồn...

--- a/README.zh.md
+++ b/README.zh.md
@@ -400,7 +400,7 @@ legacy 条目，并通过 `Status` 和 `Applies To` 标识。若没有对应的 
 将设计系统保存到文件，实现**跨会话的层级检索**：
 
 ```bash
-# 生成并持久化到 design-system/MASTER.md
+# 生成并持久化到 design-system/myapp/MASTER.md
 python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
 
 # 同时创建页面特定的覆盖文件
@@ -411,20 +411,21 @@ python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design
 
 ```
 design-system/
-├── MASTER.md           # 全局唯一真相源 (颜色、字体、间距、组件)
-└── pages/
-    └── dashboard.md    # 页面特定覆盖 (仅与主配置的偏差)
+└── myapp/                  # 每个项目一个文件夹 (-p "MyApp" 的 slug)
+    ├── MASTER.md           # 全局唯一真相源 (颜色、字体、间距、组件)
+    └── pages/
+        └── dashboard.md    # 页面特定覆盖 (仅与主配置的偏差)
 ```
 
 **层级检索工作原理：**
-1. 构建特定页面 (如"结账页") 时，先检查 `design-system/pages/checkout.md`
+1. 构建特定页面 (如"结账页") 时，先检查 `design-system/[project-slug]/pages/checkout.md`
 2. 如果页面文件存在，其规则**覆盖**主配置文件
-3. 如果不存在，仅使用 `design-system/MASTER.md`
+3. 如果不存在，仅使用 `design-system/[project-slug]/MASTER.md`
 
 **上下文感知检索提示词：**
 ```
-我正在构建 [页面名称] 页面。请阅读 design-system/MASTER.md。
-同时检查 design-system/pages/[page-name].md 是否存在。
+我正在构建 [页面名称] 页面。请阅读 design-system/[project-slug]/MASTER.md。
+同时检查 design-system/[project-slug]/pages/[page-name].md 是否存在。
 如果页面文件存在，优先使用其规则。
 如果不存在，仅使用主配置规则。
 现在，生成代码...


### PR DESCRIPTION
## Problem

`--persist` writes to `design-system/<project-slug>/MASTER.md`, but all four READMEs document `design-system/MASTER.md` and omit the per-project folder.

Following the README, a reader runs the documented command and then looks for a file that was never created at that path.

Observed with the documented example itself:

```bash
python3 .claude/skills/ui-ux-pro-max/scripts/search.py "SaaS dashboard" --design-system --persist -p "MyApp"
# -> Design system persisted to /Users/.../design-system/myapp/
#    /Users/.../design-system/myapp/MASTER.md
```

## The code is already unambiguous

`src/ui-ux-pro-max/scripts/design_system.py:1020`

```python
design_system_dir = base_dir / "design-system" / project_slug
```

And `search.py --help` documents it correctly in three places:

```
--persist   Save design system to design-system/<project-slug>/MASTER.md
--page      Create page-specific override file in design-system/<project-slug>/pages/
```

So this is a documentation gap, not a question about intended behaviour. `SKILL.md` is also already correct.

## Why the level matters

It is not incidental. Without the slug folder, two projects persisted under the same root would overwrite each other's `MASTER.md`. The README's simplified tree removes the very thing that makes multi-project use safe.

## What changed

In `README.md`, `README.ko.md`, `README.vi.md` and `README.zh.md`:

- the folder tree, with the `myapp/` level added and comments preserved and realigned
- the three "how hierarchical retrieval works" steps
- the context-aware retrieval prompt

Concrete slug `myapp` is used where the adjacent example runs `-p "MyApp"`; `[project-slug]` is used where the text describes the generic mechanism.

Documentation only — no source, data or asset files are touched.

## Verification

`validate:agent-guide` passes (20 platforms, 3 locked examples) and all 13 Playwright E2E tests pass.

`check:assets` reports the pre-existing stale `catalog-summary.json` on `main`; that is unrelated to this branch and is addressed separately in #478.
