### PR TITLE
docs: remove unimplemented openclaw install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ uipro init --ai kilocode    # KiloCode
 uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
 uipro init --ai codewhale   # CodeWhale
-uipro init --ai openclaw    # OpenClaw
 uipro init --ai universal   # Universal / Agent Standard (.agents/skills/)
 uipro init --ai all         # All assistants
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -255,7 +255,6 @@ uipro init --ai kilocode    # KiloCode
 uipro init --ai warp        # Warp
 uipro init --ai augment     # Augment
 uipro init --ai codewhale   # CodeWhale
-uipro init --ai openclaw    # OpenClaw
 uipro init --ai universal   # Universal / Agent Standard (.agents/skills/)
 uipro init --ai all         # 所有助手
 ```


### PR DESCRIPTION
## Summary
- Both `README.md` and `README.zh.md` document `uipro init --ai openclaw` as a supported install command.
- `openclaw` is not a recognized `AIType` in `cli/src/types/index.ts` (the `AIType` union and `AI_TYPES` array have no such value), so running this exact command fails.
- Removed the unimplemented line from both READMEs so the docs only list platforms the CLI actually supports.

## Test plan
- [x] Confirmed `openclaw` is absent from `cli/src/types/index.ts` (`AIType`, `AI_TYPES`, and the directory map)
- [x] Confirmed no other CLI source file references `openclaw`
- [x] Diff limited to removing the one stale line from each README

🤖 Generated with [Claude Code](https://claude.com/claude-code)