### PR TITLE
docs(cli): correct cli/README.md license from CC-BY-NC-4.0 to MIT

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -98,4 +98,4 @@ bun link
 
 ## License
 
-CC-BY-NC-4.0
+MIT


### PR DESCRIPTION
## What does this PR change?

Updates the License section in `cli/README.md` from `CC-BY-NC-4.0` to `MIT` (one line).

## Why?

Closes #481. The repository-wide license is MIT — root `LICENSE`, root `README.md`, `skill.json`, `.claude-plugin/plugin.json`, `cli/package.json`, and the npm registry metadata for `ui-ux-pro-max-cli` all declare MIT. `cli/README.md` is the only place declaring `CC-BY-NC-4.0`, which creates downstream licensing ambiguity.

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — N/A: docs-only change to `cli/README.md`, which is hand-maintained and not mirrored from `src/`
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed — no data/scripts/templates changed; `npm run check:assets` passes ("Assets are in sync")
- [x] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`) — N/A: no behavior change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
- [x] This PR targets a feature branch, not pushed directly to `main`