### PR TITLE
fix(search): warn that --stack is ignored in --design-system mode

### DIFF
--- a/.claude/skills/ui-ux-pro-max/scripts/search.py
+++ b/.claude/skills/ui-ux-pro-max/scripts/search.py
@@ -120,6 +120,12 @@ if __name__ == "__main__":
 
     # Design system takes priority
     if args.design_system:
+        if args.stack:
+            print(
+                f"note: --stack {args.stack} is ignored in --design-system mode; "
+                "run a separate --stack query for stack-specific guidelines",
+                file=sys.stderr,
+            )
         result = generate_design_system(
             args.query,
             args.project_name,

--- a/.claude/skills/ui-ux-pro-max/scripts/tests/test_design_system_stack.py
+++ b/.claude/skills/ui-ux-pro-max/scripts/tests/test_design_system_stack.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the dropped --stack flag in --design-system mode (issue #484).
+
+`search.py "<query>" --design-system --stack nextjs` used to exit successfully
+without any indication that the stack was never applied, so a caller following
+SKILL.md's "never assume a stack" guidance could believe stack guidance was
+part of the generated design system. The combination must stay valid, but it
+must say that --stack was ignored.
+
+Stdlib-only (unittest, not pytest) to match test_core.py -- this project ships
+with zero external dependencies.
+
+Run with:
+    python -m unittest discover -s scripts/tests -v
+or directly:
+    python scripts/tests/test_design_system_stack.py
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SEARCH = SCRIPTS_DIR / "search.py"
+
+
+class TestStackFlagWithDesignSystem(unittest.TestCase):
+    def run_search(self, *args):
+        # The child forces UTF-8 on its streams (search.py), so decode as UTF-8
+        # regardless of the parent's locale on Windows.
+        return subprocess.run(
+            [sys.executable, str(SEARCH), *map(str, args)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+    def test_design_system_with_stack_succeeds_and_says_stack_is_ignored(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--stack", proc.stderr)
+        self.assertIn("ignored", proc.stderr.lower())
+
+    def test_design_system_without_stack_stays_quiet(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+    def test_stack_search_alone_never_warns(self):
+        proc = self.run_search("dashboard table density", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/cli/assets/scripts/search.py
+++ b/cli/assets/scripts/search.py
@@ -120,6 +120,12 @@ if __name__ == "__main__":
 
     # Design system takes priority
     if args.design_system:
+        if args.stack:
+            print(
+                f"note: --stack {args.stack} is ignored in --design-system mode; "
+                "run a separate --stack query for stack-specific guidelines",
+                file=sys.stderr,
+            )
         result = generate_design_system(
             args.query,
             args.project_name,

--- a/cli/assets/scripts/tests/test_design_system_stack.py
+++ b/cli/assets/scripts/tests/test_design_system_stack.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the dropped --stack flag in --design-system mode (issue #484).
+
+`search.py "<query>" --design-system --stack nextjs` used to exit successfully
+without any indication that the stack was never applied, so a caller following
+SKILL.md's "never assume a stack" guidance could believe stack guidance was
+part of the generated design system. The combination must stay valid, but it
+must say that --stack was ignored.
+
+Stdlib-only (unittest, not pytest) to match test_core.py -- this project ships
+with zero external dependencies.
+
+Run with:
+    python -m unittest discover -s scripts/tests -v
+or directly:
+    python scripts/tests/test_design_system_stack.py
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SEARCH = SCRIPTS_DIR / "search.py"
+
+
+class TestStackFlagWithDesignSystem(unittest.TestCase):
+    def run_search(self, *args):
+        # The child forces UTF-8 on its streams (search.py), so decode as UTF-8
+        # regardless of the parent's locale on Windows.
+        return subprocess.run(
+            [sys.executable, str(SEARCH), *map(str, args)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+    def test_design_system_with_stack_succeeds_and_says_stack_is_ignored(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--stack", proc.stderr)
+        self.assertIn("ignored", proc.stderr.lower())
+
+    def test_design_system_without_stack_stays_quiet(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+    def test_stack_search_alone_never_warns(self):
+        proc = self.run_search("dashboard table density", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/ui-ux-pro-max/scripts/search.py
+++ b/src/ui-ux-pro-max/scripts/search.py
@@ -120,6 +120,12 @@ if __name__ == "__main__":
 
     # Design system takes priority
     if args.design_system:
+        if args.stack:
+            print(
+                f"note: --stack {args.stack} is ignored in --design-system mode; "
+                "run a separate --stack query for stack-specific guidelines",
+                file=sys.stderr,
+            )
         result = generate_design_system(
             args.query,
             args.project_name,

--- a/src/ui-ux-pro-max/scripts/tests/test_design_system_stack.py
+++ b/src/ui-ux-pro-max/scripts/tests/test_design_system_stack.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the dropped --stack flag in --design-system mode (issue #484).
+
+`search.py "<query>" --design-system --stack nextjs` used to exit successfully
+without any indication that the stack was never applied, so a caller following
+SKILL.md's "never assume a stack" guidance could believe stack guidance was
+part of the generated design system. The combination must stay valid, but it
+must say that --stack was ignored.
+
+Stdlib-only (unittest, not pytest) to match test_core.py -- this project ships
+with zero external dependencies.
+
+Run with:
+    python -m unittest discover -s scripts/tests -v
+or directly:
+    python scripts/tests/test_design_system_stack.py
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SEARCH = SCRIPTS_DIR / "search.py"
+
+
+class TestStackFlagWithDesignSystem(unittest.TestCase):
+    def run_search(self, *args):
+        # The child forces UTF-8 on its streams (search.py), so decode as UTF-8
+        # regardless of the parent's locale on Windows.
+        return subprocess.run(
+            [sys.executable, str(SEARCH), *map(str, args)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+    def test_design_system_with_stack_succeeds_and_says_stack_is_ignored(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--stack", proc.stderr)
+        self.assertIn("ignored", proc.stderr.lower())
+
+    def test_design_system_without_stack_stays_quiet(self):
+        proc = self.run_search("platform engineer dashboard", "--design-system")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+    def test_stack_search_alone_never_warns(self):
+        proc = self.run_search("dashboard table density", "--stack", "nextjs")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("ignored", proc.stderr.lower())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What does this PR change?

`search.py "<query>" --design-system --stack <name>` now prints a one-line note to stderr — `note: --stack <name> is ignored in --design-system mode; run a separate --stack query for stack-specific guidelines` — and continues exactly as before. A regression test covers the three flag combinations.

## Why?

Closes #484 (Finding 1). The combination used to exit successfully with no indication that the stack was never applied: `generate_design_system` never reads `args.stack`, and no stack file is opened in that mode. A caller following SKILL.md's "never assume a stack" guidance could reasonably believe stack guidance was part of the generated design system.

Of the two options in the triage (reject the combination, or emit a note), this PR implements the note: SKILL.md presents the search modes as alternatives, so the combination may have existing callers, and a warning closes the silence without breaking them. The note goes to stderr so `--json` output on stdout stays machine-readable. If a hard rejection is preferred, happy to switch.

## How checked?

- New `test_design_system_stack.py` (stdlib unittest, subprocess end-to-end): `--design-system --stack` exits 0 and warns on stderr; `--design-system` alone and `--stack` alone stay quiet. Verified red without the fix (fails 1) and green with it.
- Full suite the way CI runs it: `python -m pytest .claude/skills -q` → 234 passed.
- `npm run sync:assets && npm run check:assets` in `cli/` → "Assets are in sync" (source fix mirrored to `cli/assets/scripts/` and `.claude/skills/ui-ux-pro-max/scripts/`).

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — script fix in `src/ui-ux-pro-max/scripts/search.py`, mirrored by `sync:assets`
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed
- [x] Added or updated tests if behavior changed (`.claude/skills/*/scripts/tests/`, `cli/tests/e2e/`) — new `test_design_system_stack.py` in the source tests, mirrored to both shipped copies
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix:` type)
- [x] This PR targets a feature branch, not pushed directly to `main`