### PR TITLE
fix(manifests): correct style and UX guideline counts in manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "name": "nextlevelbuilder"
   },
   "metadata": {
-    "description": "UI/UX design intelligence skill with 84 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stack guidelines",
+    "description": "UI/UX design intelligence skill with 79 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stack guidelines",
     "version": "2.13.0"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-ux-pro-max",
-  "description": "UI/UX design intelligence. Searchable local database with 84 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stacks (React, Next.js, Vue, Nuxt.js, Nuxt UI, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, WPF, WinUI, Avalonia, Uno Platform, UWP, Three.js). Use when designing, building, or reviewing UI: pages, components, color schemes, typography, layout, accessibility, animation, or data visualization.",
+  "description": "UI/UX design intelligence. Searchable local database with 79 styles, 192 palettes, 74 font pairings, 25 charts, and 22 stacks (React, Next.js, Vue, Nuxt.js, Nuxt UI, Svelte, Astro, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, Jetpack Compose, Angular, Laravel, JavaFX, WPF, WinUI, Avalonia, Uno Platform, UWP, Three.js). Use when designing, building, or reviewing UI: pages, components, color schemes, typography, layout, accessibility, animation, or data visualization.",
   "version": "2.13.0",
   "author": {
     "name": "nextlevelbuilder"

--- a/skill.json
+++ b/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-ux-pro-max",
   "displayName": "UI/UX Pro Max",
-  "description": "AI-powered design intelligence with 84 UI styles, 192 color palettes, 74 font pairings, 98 UX guidelines, and 25 chart types across 22 tech stacks.",
+  "description": "AI-powered design intelligence with 79 UI styles, 192 color palettes, 74 font pairings, 119 UX guidelines, and 25 chart types across 22 tech stacks.",
   "version": "2.13.0",
   "author": "NextLevelBuilder",
   "license": "MIT",


### PR DESCRIPTION
## What does this PR change?

Corrects two stale counts in the three manifest descriptions (`skill.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`): `84 UI styles` → `79`, `98 UX guidelines` → `119`. Three lines total, one per file.

## Why?

Refs #474 (Finding 3). The manifest descriptions have drifted from the shipped data and from SKILL.md's own claims — the same recurrence #391 fixed in June, after which the CSVs kept growing. Recomputed from the canonical CSVs:

| Claimed | Actual (from `src/ui-ux-pro-max/data/`) | Verdict |
|---|---|---|
| 84 styles | `styles.csv`: 88 rows = 50 active + 29 supplemental + 9 deprecated → **79 searchable** | fixed |
| 98 UX guidelines | `ux-guidelines.csv`: **119** rows | fixed |
| 192 palettes | `colors.csv`: 192 | correct, untouched |
| 74 font pairings | `typography.csv`: 74 | correct, untouched |
| 25 charts | `charts.csv`: 25 | correct, untouched |
| 22 stacks | 22 CSVs in `data/stacks/` | correct, untouched |

The corrected values match SKILL.md ("79 searchable styles (50 active)", "119 UX guidelines") and the target values stated in the #474 triage. READMEs and docs carry no stale counts, and the manifests have no mirrored copies, so these three files are the complete surface.

## How checked?

- Counts recomputed from the CSVs (table above); `python -m json.tool` passes on all three files.
- `npm run check:assets` in `cli/` → "Assets are in sync" (no mirrored assets touched).
- Deriving these counts from the CSVs in CI would prevent the recurrence discussed in #474 — happy to explore that as a follow-up, kept out of scope here.

## Checklist

- [x] Changes were made in `src/ui-ux-pro-max/` (source of truth), not directly in `.claude/` or `.factory/` — N/A: packaging manifests only, no data/scripts/templates changed
- [x] Ran `npm run sync:assets && npm run check:assets` in `cli/` if data/scripts/templates changed — no mirrored assets affected; `check:assets` passes
- [x] Added or updated tests if behavior changed — N/A: metadata-only change, no behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(manifests):` type, matching #391)
- [x] This PR targets a feature branch, not pushed directly to `main`